### PR TITLE
Background mode v2 (Layer 1): Time Warp, Energy, audibility fix, presets

### DIFF
--- a/src/classes/AudioPlayerWrapper.ts
+++ b/src/classes/AudioPlayerWrapper.ts
@@ -107,12 +107,9 @@ export class AudioPlayerWrapper {
   /** Set this voice's playback rate (pitch + tempo) at AudioContext time `atTime`. */
   setPlaybackRate(rate: number, atTime: number): void {
     this.playbackRate = rate;
-    try {
-      this.bufferSource.playbackRate.setValueAtTime(rate, atTime);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (err) {
-      // Node not started yet; the field is applied on start().
-    }
+    // AudioParam automation is valid regardless of node state (setValueAtTime
+    // never throws for an unstarted node); start() re-seeds from the field.
+    this.bufferSource.playbackRate.setValueAtTime(rate, atTime);
   }
 
   /** Stop at `time` (AudioContext seconds). Omit to stop immediately. */

--- a/src/classes/AudioPlayerWrapper.ts
+++ b/src/classes/AudioPlayerWrapper.ts
@@ -33,6 +33,7 @@ export class AudioPlayerWrapper {
   fadeLength!: number;
   loop!: boolean;
   bufferSource!: AudioBufferSourceNode;
+  playbackRate = 1;
 
   constructor(context: AudioContext, path: string, options: AudioPlayerOptions) {
     // bind
@@ -91,11 +92,24 @@ export class AudioPlayerWrapper {
    */
   start(time: number): void {
     try {
+      this.bufferSource.playbackRate.setValueAtTime(this.playbackRate, time);
       this.bufferSource.start(time);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (err) {
       this.reload();
+      this.bufferSource.playbackRate.setValueAtTime(this.playbackRate, time);
       this.bufferSource.start(time);
+    }
+  }
+
+  /** Set this voice's playback rate (pitch + tempo) at AudioContext time `atTime`. */
+  setPlaybackRate(rate: number, atTime: number): void {
+    this.playbackRate = rate;
+    try {
+      this.bufferSource.playbackRate.setValueAtTime(rate, atTime);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (err) {
+      // Node not started yet; the field is applied on start().
     }
   }
 
@@ -118,6 +132,7 @@ export class AudioPlayerWrapper {
     newSource.loop = this.loop;
     newSource.loopStart = 0;
     newSource.loopEnd = this.bufferSource.buffer!.duration;
+    newSource.playbackRate.value = this.playbackRate;
     newSource.connect(this.destination);
 
     this.bufferSource = newSource;

--- a/src/classes/AudioPlayerWrapper.ts
+++ b/src/classes/AudioPlayerWrapper.ts
@@ -93,7 +93,7 @@ export class AudioPlayerWrapper {
   start(time: number): void {
     try {
       // Seed the rate as the source's base value (not an event pinned at `time`),
-      // so a Drift change between scheduling and `time` still governs the rate the
+      // so a Time Warp change between scheduling and `time` still governs the rate the
       // voice comes in at — otherwise it starts at a stale rate (wrong pitch+tempo).
       this.bufferSource.playbackRate.value = this.playbackRate;
       this.bufferSource.start(time);

--- a/src/classes/AudioPlayerWrapper.ts
+++ b/src/classes/AudioPlayerWrapper.ts
@@ -92,12 +92,14 @@ export class AudioPlayerWrapper {
    */
   start(time: number): void {
     try {
-      this.bufferSource.playbackRate.setValueAtTime(this.playbackRate, time);
+      // Seed the rate as the source's base value (not an event pinned at `time`),
+      // so a Drift change between scheduling and `time` still governs the rate the
+      // voice comes in at — otherwise it starts at a stale rate (wrong pitch+tempo).
+      this.bufferSource.playbackRate.value = this.playbackRate;
       this.bufferSource.start(time);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (err) {
       this.reload();
-      this.bufferSource.playbackRate.setValueAtTime(this.playbackRate, time);
       this.bufferSource.start(time);
     }
   }

--- a/src/classes/AudioPlayerWrapper.ts
+++ b/src/classes/AudioPlayerWrapper.ts
@@ -34,6 +34,8 @@ export class AudioPlayerWrapper {
   loop!: boolean;
   bufferSource!: AudioBufferSourceNode;
   playbackRate = 1;
+  /** True from `start()` until `stop()`; gates AudioParam work in `setPlaybackRate`. */
+  private playing = false;
 
   constructor(context: AudioContext, path: string, options: AudioPlayerOptions) {
     // bind
@@ -102,18 +104,34 @@ export class AudioPlayerWrapper {
       this.reload();
       this.bufferSource.start(time);
     }
+    this.playing = true;
   }
 
-  /** Set this voice's playback rate (pitch + tempo) at AudioContext time `atTime`. */
-  setPlaybackRate(rate: number, atTime: number): void {
+  /**
+   * Set this voice's playback rate (pitch + tempo) at AudioContext time `atTime`.
+   * With `glideSeconds > 0`, the rate ramps linearly from the param's current
+   * value to `rate` over that window (anchored with setValueAtTime so
+   * consecutive ramps chain continuously instead of zippering).
+   *
+   * The rate is always recorded so a later `start()` seeds the live value, but
+   * AudioParam automation only touches a playing source — automating stopped or
+   * not-yet-started nodes is wasted work (a fresh node is seeded on start).
+   */
+  setPlaybackRate(rate: number, atTime: number, glideSeconds = 0): void {
     this.playbackRate = rate;
-    // AudioParam automation is valid regardless of node state (setValueAtTime
-    // never throws for an unstarted node); start() re-seeds from the field.
-    this.bufferSource.playbackRate.setValueAtTime(rate, atTime);
+    if (!this.playing) return;
+    const param = this.bufferSource.playbackRate;
+    if (glideSeconds > 0) {
+      param.setValueAtTime(param.value, atTime);
+      param.linearRampToValueAtTime(rate, atTime + glideSeconds);
+    } else {
+      param.setValueAtTime(rate, atTime);
+    }
   }
 
   /** Stop at `time` (AudioContext seconds). Omit to stop immediately. */
   stop(time?: number): void {
+    this.playing = false;
     try {
       this.bufferSource.stop(time);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/classes/TempoClock.ts
+++ b/src/classes/TempoClock.ts
@@ -1,0 +1,70 @@
+/**
+ * Single source of truth for musical time under a variable playback rate.
+ *
+ * The original grid (`nextSubdivision` in audioUtils) maps wall-clock seconds to
+ * beats with a constant BPM. Drift changes the rate, so the grid must integrate a
+ * rate that can change. This clock does that by re-anchoring on every rate change:
+ * between changes the rate is constant, so beats <-> time is a simple linear map,
+ * and the accumulated beat count carries across changes for continuity.
+ *
+ * At rate 1 anchored at time 0 it is identical to `nextSubdivision`. Times are
+ * AudioContext seconds passed in by the caller, which keeps this class pure (no
+ * AudioContext reference) and trivially unit-testable.
+ */
+export class TempoClock {
+  private readonly beatsPerSecondAtRate1: number;
+  private anchorTime = 0;
+  private anchorBeats = 0;
+  private rate = 1;
+
+  constructor(baseBpm: number) {
+    this.beatsPerSecondAtRate1 = baseBpm / 60;
+  }
+
+  /** Beats elapsed at AudioContext time `time`, under the current rate. */
+  beatsAt(time: number): number {
+    return (
+      this.anchorBeats +
+      (time - this.anchorTime) * this.beatsPerSecondAtRate1 * this.rate
+    );
+  }
+
+  /** AudioContext time at which `beats` total beats will have elapsed. */
+  timeAt(beats: number): number {
+    return (
+      this.anchorTime +
+      (beats - this.anchorBeats) / (this.beatsPerSecondAtRate1 * this.rate)
+    );
+  }
+
+  /**
+   * Re-anchor to a new rate at AudioContext time `now`, preserving beat
+   * continuity. Call this at the same instant the voices' playbackRate is set to
+   * `rate`, so the clock and the audio agree.
+   */
+  setRate(rate: number, now: number): void {
+    this.anchorBeats = this.beatsAt(now);
+    this.anchorTime = now;
+    this.rate = rate;
+  }
+
+  /**
+   * AudioContext time of the next boundary that is a whole multiple of
+   * `intervalBeats`, strictly after `fromTime`. Drift-aware replacement for
+   * `nextSubdivision`.
+   */
+  nextBoundary(intervalBeats: number, fromTime: number): number {
+    const beatsNow = this.beatsAt(fromTime);
+    const nextMultiple =
+      (Math.floor(beatsNow / intervalBeats) + 1) * intervalBeats;
+    return this.timeAt(nextMultiple);
+  }
+
+  get currentRate(): number {
+    return this.rate;
+  }
+
+  get effectiveBpm(): number {
+    return this.beatsPerSecondAtRate1 * 60 * this.rate;
+  }
+}

--- a/src/classes/TempoClock.ts
+++ b/src/classes/TempoClock.ts
@@ -2,7 +2,7 @@
  * Single source of truth for musical time under a variable playback rate.
  *
  * The original grid (`nextSubdivision` in audioUtils) maps wall-clock seconds to
- * beats with a constant BPM. Drift changes the rate, so the grid must integrate a
+ * beats with a constant BPM. Time Warp changes the rate, so the grid must integrate a
  * rate that can change. This clock does that by re-anchoring on every rate change:
  * between changes the rate is constant, so beats <-> time is a simple linear map,
  * and the accumulated beat count carries across changes for continuity.
@@ -61,7 +61,7 @@ export class TempoClock {
 
   /**
    * AudioContext time of the next boundary that is a whole multiple of
-   * `intervalBeats`, strictly after `fromTime`. Drift-aware replacement for
+   * `intervalBeats`, strictly after `fromTime`. Time-Warp-aware replacement for
    * `nextSubdivision`.
    */
   nextBoundary(intervalBeats: number, fromTime: number): number {

--- a/src/classes/TempoClock.ts
+++ b/src/classes/TempoClock.ts
@@ -49,15 +49,23 @@ export class TempoClock {
   }
 
   /**
+   * Beat count of the next boundary that is a whole multiple of `intervalBeats`,
+   * strictly after `fromTime`. The beat count is rate-invariant: as the rate
+   * changes, this target stays fixed while its wall-clock time (`timeAt`) moves,
+   * which is what lets a pending voice re-resolve its start against the live grid.
+   */
+  nextBoundaryBeat(intervalBeats: number, fromTime: number): number {
+    const beatsNow = this.beatsAt(fromTime);
+    return (Math.floor(beatsNow / intervalBeats) + 1) * intervalBeats;
+  }
+
+  /**
    * AudioContext time of the next boundary that is a whole multiple of
    * `intervalBeats`, strictly after `fromTime`. Drift-aware replacement for
    * `nextSubdivision`.
    */
   nextBoundary(intervalBeats: number, fromTime: number): number {
-    const beatsNow = this.beatsAt(fromTime);
-    const nextMultiple =
-      (Math.floor(beatsNow / intervalBeats) + 1) * intervalBeats;
-    return this.timeAt(nextMultiple);
+    return this.timeAt(this.nextBoundaryBeat(intervalBeats, fromTime));
   }
 
   get currentRate(): number {

--- a/src/classes/WebAudioWrapper.ts
+++ b/src/classes/WebAudioWrapper.ts
@@ -68,8 +68,8 @@ interface TransportRequest {
   onCommit: (time: number) => void;
 }
 
-/** Poll period (ms) and commit horizon (s) for the boundary transport. */
-const TRANSPORT_TICK_MS = 15;
+/** Poll period and commit horizon (seconds) for the boundary transport. */
+const TRANSPORT_TICK = 0.015;
 const TRANSPORT_LOOKAHEAD = 0.04;
 
 /**
@@ -94,7 +94,7 @@ export class WebAudioWrapper {
   scheduler: Scheduler;
   tempoClocks: Partial<Record<SongId, TempoClock>> = {};
   private transportQueue = new Map<string, TransportRequest>();
-  private transportTimer: number | null = null;
+  private transportTick: number | null = null;
 
   constructor(appConfig: AppConfigEntry[]) {
     const props = {
@@ -492,17 +492,29 @@ export class WebAudioWrapper {
       this.audioCtx.currentTime
     );
     this.transportQueue.set(key, { player, clock, targetBeat, action, onCommit });
-    if (this.transportTimer === null) {
-      this.transportTimer = window.setInterval(
-        () => this.tickTransport(),
-        TRANSPORT_TICK_MS
-      );
+    if (this.transportTick === null) {
+      this.armTransportTick();
     }
   }
 
   /** Drop a pending boundary request (re-toggle before it commits, or unmount). */
   cancelBoundary(key: string): void {
     this.transportQueue.delete(key);
+  }
+
+  /**
+   * Arm the next transport poll on the audio clock via the Scheduler. Window
+   * timers are throttled to >= 1s in background tabs, which would let a boundary
+   * slip into the past before the tick observes it (Web Audio then clamps the
+   * start to "now" — audibly off-grid). Scheduler events fire off the audio
+   * clock (a dummy BufferSource's `onended`) and are immune to that throttling.
+   * Each tick re-arms itself only while requests remain pending.
+   */
+  private armTransportTick(): void {
+    this.transportTick = this.scheduler.scheduleOnce(
+      this.audioCtx.currentTime + TRANSPORT_TICK,
+      () => this.tickTransport()
+    ) as number;
   }
 
   private tickTransport(): void {
@@ -519,9 +531,10 @@ export class WebAudioWrapper {
         this.transportQueue.delete(key);
       }
     }
-    if (this.transportQueue.size === 0 && this.transportTimer !== null) {
-      window.clearInterval(this.transportTimer);
-      this.transportTimer = null;
+    if (this.transportQueue.size > 0) {
+      this.armTransportTick();
+    } else {
+      this.transportTick = null;
     }
   }
 

--- a/src/classes/WebAudioWrapper.ts
+++ b/src/classes/WebAudioWrapper.ts
@@ -10,6 +10,7 @@ import { loadArrayBuffer } from "../utils/audioUtils";
 import { Analyser } from "./Analyser";
 import { Scheduler } from "./Scheduler";
 import { AudioPlayerWrapper } from "./AudioPlayerWrapper";
+import { TempoClock } from "./TempoClock";
 import {
   SongContextValue,
   AppConfigEntry,
@@ -79,6 +80,7 @@ export class WebAudioWrapper {
   status: Record<SongId, boolean>;
   audioCtx: AudioContext;
   scheduler: Scheduler;
+  tempoClocks: Partial<Record<SongId, TempoClock>> = {};
 
   constructor(appConfig: AppConfigEntry[]) {
     const props = {
@@ -152,6 +154,7 @@ export class WebAudioWrapper {
       await this._initSongEffects(id);
       await this._initSongAnalysers(id);
       await this._initSongVoices(id);
+      this.tempoClocks[id] = new TempoClock(this.config[id].bpm);
       this.status[id] = true;
     }
     return true;
@@ -435,6 +438,24 @@ export class WebAudioWrapper {
 
   getVoices(songId: SongId): Record<string, AudioPlayerWrapper> {
     return this.nodes.voices![songId]!;
+  }
+
+  getTempoClock(songId: SongId): TempoClock {
+    return this.tempoClocks[songId]!;
+  }
+
+  /**
+   * Apply a playback `rate` (1 = normal, 0.5 = the Drift floor) to the song's
+   * tempo clock and every one of its voices at the current time. Instant; the
+   * Drift knob steps this to produce a glide.
+   */
+  setDriftRate(songId: SongId, rate: number): void {
+    const now = this.audioCtx.currentTime;
+    this.getTempoClock(songId).setRate(rate, now);
+    const voices = this.getVoices(songId);
+    for (const name in voices) {
+      voices[name].setPlaybackRate(rate, now);
+    }
   }
 
   getConfig(songId: SongId): Omit<SongContextValue, "id"> {

--- a/src/classes/WebAudioWrapper.ts
+++ b/src/classes/WebAudioWrapper.ts
@@ -66,6 +66,7 @@ interface TransportRequest {
   targetBeat: number;
   action: "start" | "stop";
   onCommit: (time: number) => void;
+  onRetime?: (time: number) => void;
 }
 
 /** Poll period and commit horizon (seconds) for the boundary transport. */
@@ -465,10 +466,18 @@ export class WebAudioWrapper {
    */
   setTimeWarpRate(songId: SongId, rate: number): void {
     const now = this.audioCtx.currentTime;
-    this.getTempoClock(songId).setRate(rate, now);
+    const clock = this.getTempoClock(songId);
+    clock.setRate(rate, now);
     const voices = this.getVoices(songId);
     for (const name in voices) {
       voices[name].setPlaybackRate(rate, now);
+    }
+    // The rate change moves every pending boundary's wall-clock time; hand the
+    // re-resolved time to each requester so its countdown follows the live grid.
+    for (const req of this.transportQueue.values()) {
+      if (req.clock === clock) {
+        req.onRetime?.(clock.timeAt(req.targetBeat));
+      }
     }
   }
 
@@ -478,6 +487,9 @@ export class WebAudioWrapper {
    * horizon. Committing late means the boundary's wall-clock time is resolved
    * against the live clock — so a Time Warp change mid-glide can't leave a voice
    * scheduled against a stale grid. `key` (the voice name) dedupes and cancels.
+   * `onRetime`, when given, fires on every Time Warp change while the request is
+   * pending, with the boundary's re-resolved wall-clock time — the toggle
+   * countdown animation uses it to finish exactly when the commit lands.
    */
   scheduleAtBoundary(
     key: string,
@@ -485,13 +497,21 @@ export class WebAudioWrapper {
     clock: TempoClock,
     intervalBeats: number,
     action: "start" | "stop",
-    onCommit: (time: number) => void
+    onCommit: (time: number) => void,
+    onRetime?: (time: number) => void
   ): void {
     const targetBeat = clock.nextBoundaryBeat(
       intervalBeats,
       this.audioCtx.currentTime
     );
-    this.transportQueue.set(key, { player, clock, targetBeat, action, onCommit });
+    this.transportQueue.set(key, {
+      player,
+      clock,
+      targetBeat,
+      action,
+      onCommit,
+      onRetime,
+    });
     if (this.transportTick === null) {
       this.armTransportTick();
     }

--- a/src/classes/WebAudioWrapper.ts
+++ b/src/classes/WebAudioWrapper.ts
@@ -60,6 +60,18 @@ interface WrapperValues {
   am: number[];
 }
 
+interface TransportRequest {
+  player: AudioPlayerWrapper;
+  clock: TempoClock;
+  targetBeat: number;
+  action: "start" | "stop";
+  onCommit: (time: number) => void;
+}
+
+/** Poll period (ms) and commit horizon (s) for the boundary transport. */
+const TRANSPORT_TICK_MS = 15;
+const TRANSPORT_LOOKAHEAD = 0.04;
+
 /**
  * Central audio engine. Owns the AudioContext, Scheduler, and the entire WebAudio
  * node graph for the app.
@@ -81,6 +93,8 @@ export class WebAudioWrapper {
   audioCtx: AudioContext;
   scheduler: Scheduler;
   tempoClocks: Partial<Record<SongId, TempoClock>> = {};
+  private transportQueue = new Map<string, TransportRequest>();
+  private transportTimer: number | null = null;
 
   constructor(appConfig: AppConfigEntry[]) {
     const props = {
@@ -455,6 +469,59 @@ export class WebAudioWrapper {
     const voices = this.getVoices(songId);
     for (const name in voices) {
       voices[name].setPlaybackRate(rate, now);
+    }
+  }
+
+  /**
+   * Queue a voice to start/stop on the next `intervalBeats` boundary, committing
+   * the actual `start`/`stop` only once that boundary is within the look-ahead
+   * horizon. Committing late means the boundary's wall-clock time is resolved
+   * against the live clock — so a Drift change mid-glide can't leave a voice
+   * scheduled against a stale grid. `key` (the voice name) dedupes and cancels.
+   */
+  scheduleAtBoundary(
+    key: string,
+    player: AudioPlayerWrapper,
+    clock: TempoClock,
+    intervalBeats: number,
+    action: "start" | "stop",
+    onCommit: (time: number) => void
+  ): void {
+    const targetBeat = clock.nextBoundaryBeat(
+      intervalBeats,
+      this.audioCtx.currentTime
+    );
+    this.transportQueue.set(key, { player, clock, targetBeat, action, onCommit });
+    if (this.transportTimer === null) {
+      this.transportTimer = window.setInterval(
+        () => this.tickTransport(),
+        TRANSPORT_TICK_MS
+      );
+    }
+  }
+
+  /** Drop a pending boundary request (re-toggle before it commits, or unmount). */
+  cancelBoundary(key: string): void {
+    this.transportQueue.delete(key);
+  }
+
+  private tickTransport(): void {
+    const now = this.audioCtx.currentTime;
+    for (const [key, req] of this.transportQueue) {
+      const time = req.clock.timeAt(req.targetBeat);
+      if (time <= now + TRANSPORT_LOOKAHEAD) {
+        if (req.action === "start") {
+          req.player.start(time);
+        } else {
+          req.player.stop(time);
+        }
+        req.onCommit(time);
+        this.transportQueue.delete(key);
+      }
+    }
+    if (this.transportQueue.size === 0 && this.transportTimer !== null) {
+      window.clearInterval(this.transportTimer);
+      this.transportTimer = null;
     }
   }
 

--- a/src/classes/WebAudioWrapper.ts
+++ b/src/classes/WebAudioWrapper.ts
@@ -94,6 +94,14 @@ export class WebAudioWrapper {
   audioCtx: AudioContext;
   scheduler: Scheduler;
   tempoClocks: Partial<Record<SongId, TempoClock>> = {};
+  /**
+   * Last commanded Time Warp rate per song. During a glide this is the audio
+   * ramp's anchor (where the previous segment's ramp landed), which the clock's
+   * midpoint rate must pair with `rate` — the clock's own `currentRate` is a
+   * held midpoint mid-glide, and pairing midpoints compounds into a permanent
+   * clock/audio phase offset.
+   */
+  private timeWarpTargets: Partial<Record<SongId, number>> = {};
   private transportQueue = new Map<string, TransportRequest>();
   private transportTick: number | null = null;
 
@@ -461,16 +469,28 @@ export class WebAudioWrapper {
 
   /**
    * Apply a playback `rate` (1 = normal, 0.5 = the Time Warp floor) to the song's
-   * tempo clock and every one of its voices at the current time. Instant; the
-   * Time Warp knob steps this to produce a glide.
+   * tempo clock and every one of its voices. With `glideSeconds > 0` the voices
+   * ramp linearly to `rate` over that window instead of jumping — the Time Warp
+   * knob chains one such call per glide step for a click-free glide.
+   *
+   * The clock cannot ramp: TempoClock's position math assumes a piecewise-
+   * constant rate. Each gliding segment instead holds the midpoint of (previous
+   * commanded rate, `rate`) — by the trapezoid rule the clock's beat integral
+   * then equals the linear ramp's integral exactly at every segment end; within a
+   * segment they diverge by at most (rate delta x glideSeconds / 8): well under
+   * a millisecond of musical position. The glide's final settle call (no glide)
+   * re-pins clock and audio to the same exact rate.
    */
-  setTimeWarpRate(songId: SongId, rate: number): void {
+  setTimeWarpRate(songId: SongId, rate: number, glideSeconds = 0): void {
     const now = this.audioCtx.currentTime;
     const clock = this.getTempoClock(songId);
-    clock.setRate(rate, now);
+    const prevTarget = this.timeWarpTargets[songId] ?? clock.currentRate;
+    const clockRate = glideSeconds > 0 ? (prevTarget + rate) / 2 : rate;
+    this.timeWarpTargets[songId] = rate;
+    clock.setRate(clockRate, now);
     const voices = this.getVoices(songId);
     for (const name in voices) {
-      voices[name].setPlaybackRate(rate, now);
+      voices[name].setPlaybackRate(rate, now, glideSeconds);
     }
     // The rate change moves every pending boundary's wall-clock time; hand the
     // re-resolved time to each requester so its countdown follows the live grid.

--- a/src/classes/WebAudioWrapper.ts
+++ b/src/classes/WebAudioWrapper.ts
@@ -459,11 +459,11 @@ export class WebAudioWrapper {
   }
 
   /**
-   * Apply a playback `rate` (1 = normal, 0.5 = the Drift floor) to the song's
+   * Apply a playback `rate` (1 = normal, 0.5 = the Time Warp floor) to the song's
    * tempo clock and every one of its voices at the current time. Instant; the
-   * Drift knob steps this to produce a glide.
+   * Time Warp knob steps this to produce a glide.
    */
-  setDriftRate(songId: SongId, rate: number): void {
+  setTimeWarpRate(songId: SongId, rate: number): void {
     const now = this.audioCtx.currentTime;
     this.getTempoClock(songId).setRate(rate, now);
     const voices = this.getVoices(songId);
@@ -476,7 +476,7 @@ export class WebAudioWrapper {
    * Queue a voice to start/stop on the next `intervalBeats` boundary, committing
    * the actual `start`/`stop` only once that boundary is within the look-ahead
    * horizon. Committing late means the boundary's wall-clock time is resolved
-   * against the live clock — so a Drift change mid-glide can't leave a voice
+   * against the live clock — so a Time Warp change mid-glide can't leave a voice
    * scheduled against a stale grid. `key` (the voice name) dedupes and cancels.
    */
   scheduleAtBoundary(

--- a/src/components/EffectsPanel.tsx
+++ b/src/components/EffectsPanel.tsx
@@ -19,7 +19,12 @@ import { flexPanel } from "../styles/shared/layout.css";
 import { buttonWhite, groupedButtons } from "../styles/shared/buttons.css";
 import { cx } from "../utils/cx";
 
-const EFFECT_INTERVAL = 4; // in beats
+// Effect random-walk timing (beats). The interval is both the spacing between new
+// targets and the transition length, so Energy scales the modulation: calm = slow
+// and sweeping, lively = quicker. The tick is the lerp update granularity.
+const CALM_EFFECT_BEATS = 128;
+const LIVELY_EFFECT_BEATS = 32;
+const EFFECT_TICK_BEATS = 0.25;
 
 // Background-mode safe zone for the effect walk so it can never bury the song:
 // the highpass stays <= ~1 kHz (value 72) and the lowpass >= ~3 kHz (value 55).
@@ -47,10 +52,12 @@ interface Preset {
   ambience: number;
 }
 
-// Slider positions (1-100). Work = present and steady; Ambient = dreamy and slow.
-const PRESETS: Record<"ambient" | "work", Preset> = {
-  ambient: { timeWarp: 40, energy: 25, ambience: 45 },
+// Slider positions (1-100), as a spectrum from present to deeply calm:
+// Work = steady focus bed; Ambient = dreamy and slow; Sleep = slowest and sparsest.
+const PRESETS: Record<"work" | "ambient" | "sleep", Preset> = {
   work: { timeWarp: 1, energy: 50, ambience: 10 },
+  ambient: { timeWarp: 40, energy: 25, ambience: 45 },
+  sleep: { timeWarp: 85, energy: 8, ambience: 70 },
 };
 
 export const EffectsPanel = () => {
@@ -87,7 +94,9 @@ export const EffectsPanel = () => {
   });
 
   const triggerRandomEffects = () => {
-    const intervalSeconds = (EFFECT_INTERVAL * 60) / bpm;
+    const energy = (energyValue - 1) / 99;
+    const intervalSeconds =
+      (lerp(CALM_EFFECT_BEATS, LIVELY_EFFECT_BEATS, energy) * 60) / bpm;
     if (
       !effectsTargets.current.time ||
       effectsTargets.current.time < WAW.audioCtx.currentTime - intervalSeconds
@@ -121,7 +130,7 @@ export const EffectsPanel = () => {
     ) {
       backgroundModeEventRef.current = WAW.scheduler.scheduleRepeating(
         WAW.audioCtx.currentTime + 60 / bpm,
-        (EFFECT_INTERVAL * 60) / bpm / 16,
+        (EFFECT_TICK_BEATS * 60) / bpm,
         triggerRandomEffects
       );
       // update event
@@ -194,6 +203,13 @@ export const EffectsPanel = () => {
       <div className="flex-row">
         <button
           className={cx(buttonWhite, groupedButtons)}
+          id="preset-work"
+          onClick={() => applyPreset(PRESETS.work)}
+        >
+          Work
+        </button>
+        <button
+          className={cx(buttonWhite, groupedButtons)}
           id="preset-ambient"
           onClick={() => applyPreset(PRESETS.ambient)}
         >
@@ -201,10 +217,10 @@ export const EffectsPanel = () => {
         </button>
         <button
           className={cx(buttonWhite, groupedButtons)}
-          id="preset-work"
-          onClick={() => applyPreset(PRESETS.work)}
+          id="preset-sleep"
+          onClick={() => applyPreset(PRESETS.sleep)}
         >
-          Work
+          Sleep
         </button>
       </div>
 
@@ -322,6 +338,7 @@ export const EffectsPanel = () => {
         <button
           className={cx(buttonWhite, groupedButtons)}
           id="effects-panel-reset"
+          disabled={backgroundMode}
           onClick={() => {
             setHpValue(1);
             setLpValue(100);
@@ -337,6 +354,7 @@ export const EffectsPanel = () => {
         <button
           className={cx(buttonWhite, groupedButtons)}
           id="effects-panel-randomize"
+          disabled={backgroundMode}
           onClick={() => {
             const h = 1 + 99 * Math.random();
             const l = 1 + 99 * Math.random();

--- a/src/components/EffectsPanel.tsx
+++ b/src/components/EffectsPanel.tsx
@@ -43,6 +43,7 @@ export const EffectsPanel = () => {
   );
   const setPauseVisuals = useMusicPlayerStore((s) => s.setPauseVisuals);
   const setTimeWarp = useMusicPlayerStore((s) => s.setTimeWarp);
+  const setEnergy = useMusicPlayerStore((s) => s.setEnergy);
   const { bpm, id } = useContext(SongContext)!;
   const { WAW } = useContext(WebAudioContext)!;
 
@@ -54,6 +55,7 @@ export const EffectsPanel = () => {
   const [amValue, setAmValue] = useState(1);
   const [timeWarpValue, setTimeWarpValue] = useState(1);
   const timeWarpGlideRef = useRef<number | null>(null);
+  const [energyValue, setEnergyValue] = useState(50);
 
   const effectsTargets = useRef<{
     time: number | null;
@@ -149,6 +151,11 @@ export const EffectsPanel = () => {
         timeWarpGlideRef.current = null;
       }
     }, 30);
+  };
+
+  const handleEnergy = (v: number) => {
+    setEnergyValue(v);
+    setEnergy((v - 1) / 99);
   };
 
   return (
@@ -275,6 +282,16 @@ export const EffectsPanel = () => {
           id="time-warp"
           value={timeWarpValue}
           handleValue={handleTimeWarp}
+        />
+      </div>
+      <div className="flex-row">
+        <h3 className={sliderLabel}>energy</h3>
+      </div>
+      <div className="flex-row">
+        <CanvasSlider
+          id="energy"
+          value={energyValue}
+          handleValue={handleEnergy}
         />
       </div>
       <div className="flex-row">

--- a/src/components/EffectsPanel.tsx
+++ b/src/components/EffectsPanel.tsx
@@ -42,7 +42,7 @@ export const EffectsPanel = () => {
     (s) => s.setBackgroundMode
   );
   const setPauseVisuals = useMusicPlayerStore((s) => s.setPauseVisuals);
-  const setDrift = useMusicPlayerStore((s) => s.setDrift);
+  const setTimeWarp = useMusicPlayerStore((s) => s.setTimeWarp);
   const { bpm, id } = useContext(SongContext)!;
   const { WAW } = useContext(WebAudioContext)!;
 
@@ -52,8 +52,8 @@ export const EffectsPanel = () => {
   const [hpValue, setHpValue] = useState(1);
   const [lpValue, setLpValue] = useState(100);
   const [amValue, setAmValue] = useState(1);
-  const [driftValue, setDriftValue] = useState(1);
-  const driftGlideRef = useRef<number | null>(null);
+  const [timeWarpValue, setTimeWarpValue] = useState(1);
+  const timeWarpGlideRef = useRef<number | null>(null);
 
   const effectsTargets = useRef<{
     time: number | null;
@@ -130,23 +130,23 @@ export const EffectsPanel = () => {
   }, [WAW, amValue]);
 
   // slider 1..100 -> rate 1.0..0.5 (one octave / half tempo at the floor)
-  const driftToRate = (v: number) => 1 - ((v - 1) / 99) * 0.5;
+  const timeWarpToRate = (v: number) => 1 - ((v - 1) / 99) * 0.5;
 
-  const handleDrift = (v: number) => {
-    setDriftValue(v);
-    setDrift((v - 1) / 99);
-    const targetRate = driftToRate(v);
+  const handleTimeWarp = (v: number) => {
+    setTimeWarpValue(v);
+    setTimeWarp((v - 1) / 99);
+    const targetRate = timeWarpToRate(v);
     const startRate = WAW.getTempoClock(id).currentRate;
     const steps = 20;
     let i = 0;
-    if (driftGlideRef.current) window.clearInterval(driftGlideRef.current);
-    driftGlideRef.current = window.setInterval(() => {
+    if (timeWarpGlideRef.current) window.clearInterval(timeWarpGlideRef.current);
+    timeWarpGlideRef.current = window.setInterval(() => {
       i++;
       const r = startRate + (targetRate - startRate) * (i / steps);
-      WAW.setDriftRate(id, r);
+      WAW.setTimeWarpRate(id, r);
       if (i >= steps) {
-        window.clearInterval(driftGlideRef.current!);
-        driftGlideRef.current = null;
+        window.clearInterval(timeWarpGlideRef.current!);
+        timeWarpGlideRef.current = null;
       }
     }, 30);
   };
@@ -268,10 +268,14 @@ export const EffectsPanel = () => {
       </div>
 
       <div className="flex-row">
-        <h3 className={sliderLabel}>drift</h3>
+        <h3 className={sliderLabel}>time warp</h3>
       </div>
       <div className="flex-row">
-        <CanvasSlider id="drift" value={driftValue} handleValue={handleDrift} />
+        <CanvasSlider
+          id="time-warp"
+          value={timeWarpValue}
+          handleValue={handleTimeWarp}
+        />
       </div>
       <div className="flex-row">
         <h3 className={sliderLabel}>highpass filter</h3>

--- a/src/components/EffectsPanel.tsx
+++ b/src/components/EffectsPanel.tsx
@@ -32,6 +32,14 @@ const EFFECT_TICK_BEATS = 0.25;
 const HP_WALK_CEIL = 72;
 const LP_WALK_FLOOR = 55;
 
+// Manual Time Warp glide: the rate eases to its target over GLIDE_STEPS
+// segments of GLIDE_STEP_S each. Each step ramps the audio linearly across the
+// segment while the clock holds a matching piecewise-constant rate (see
+// WebAudioWrapper.setTimeWarpRate); a final settle tick pins both to the exact
+// target.
+const GLIDE_STEPS = 20;
+const GLIDE_STEP_S = 0.03;
+
 // The edge-avoidance margin (bounds) and step size (effectSize) were tuned on
 // the full 1-100 range as 35 and 40; they scale with the actual range so a
 // narrowed safe zone (e.g. the background-mode lp walk, 55-100) wanders the same
@@ -171,18 +179,21 @@ export const EffectsPanel = () => {
     setTimeWarp((v - 1) / 99);
     const targetRate = timeWarpToRate(v);
     const startRate = WAW.getTempoClock(id).currentRate;
-    const steps = 20;
     let i = 0;
     if (timeWarpGlideRef.current) window.clearInterval(timeWarpGlideRef.current);
     timeWarpGlideRef.current = window.setInterval(() => {
       i++;
-      const r = startRate + (targetRate - startRate) * (i / steps);
-      WAW.setTimeWarpRate(id, r);
-      if (i >= steps) {
+      if (i <= GLIDE_STEPS) {
+        const r = startRate + (targetRate - startRate) * (i / GLIDE_STEPS);
+        WAW.setTimeWarpRate(id, r, GLIDE_STEP_S);
+      } else {
+        // settle: the last ramp segment has landed; pin clock and audio to the
+        // exact target rate
+        WAW.setTimeWarpRate(id, targetRate);
         window.clearInterval(timeWarpGlideRef.current!);
         timeWarpGlideRef.current = null;
       }
-    }, 30);
+    }, GLIDE_STEP_S * 1000);
   };
 
   const handleEnergy = (v: number) => {

--- a/src/components/EffectsPanel.tsx
+++ b/src/components/EffectsPanel.tsx
@@ -11,7 +11,6 @@ import { CanvasSlider } from "./canvas/CanvasSlider";
 import {
   sliderLabel,
   sliderRow,
-  effectsControlsRow,
   switchControl,
   slider,
   round,
@@ -42,6 +41,18 @@ const chooseNewValue = (prev: number, min = 1, max = 100): number => {
   return clamp(newValue, min, max);
 };
 
+interface Preset {
+  timeWarp: number;
+  energy: number;
+  ambience: number;
+}
+
+// Slider positions (1-100). Work = present and steady; Ambient = dreamy and slow.
+const PRESETS: Record<"ambient" | "work", Preset> = {
+  ambient: { timeWarp: 40, energy: 25, ambience: 45 },
+  work: { timeWarp: 1, energy: 50, ambience: 10 },
+};
+
 export const EffectsPanel = () => {
   const setVoicesBackgroundMode = useMusicPlayerStore(
     (s) => s.setBackgroundMode
@@ -49,6 +60,7 @@ export const EffectsPanel = () => {
   const setPauseVisuals = useMusicPlayerStore((s) => s.setPauseVisuals);
   const setTimeWarp = useMusicPlayerStore((s) => s.setTimeWarp);
   const setEnergy = useMusicPlayerStore((s) => s.setEnergy);
+  const voicesOn = useMusicPlayerStore((s) => s.backgroundMode);
   const { bpm, id } = useContext(SongContext)!;
   const { WAW } = useContext(WebAudioContext)!;
 
@@ -163,6 +175,15 @@ export const EffectsPanel = () => {
     setEnergy((v - 1) / 99);
   };
 
+  const applyPreset = (p: Preset) => {
+    handleTimeWarp(p.timeWarp);
+    handleEnergy(p.energy);
+    setAmValue(p.ambience);
+    WAW.setEffects("am", p.ambience);
+    setVoicesBackgroundMode(true);
+    setBackgroundMode(true);
+  };
+
   return (
     <div id="effects-panel" className={flexPanel}>
       <h2>Background Mode</h2>
@@ -170,15 +191,30 @@ export const EffectsPanel = () => {
         Automatically varies the music over time. Ideal for extended listening.
       </p>
 
+      <div className="flex-row">
+        <button
+          className={cx(buttonWhite, groupedButtons)}
+          id="preset-ambient"
+          onClick={() => applyPreset(PRESETS.ambient)}
+        >
+          Ambient
+        </button>
+        <button
+          className={cx(buttonWhite, groupedButtons)}
+          id="preset-work"
+          onClick={() => applyPreset(PRESETS.work)}
+        >
+          Work
+        </button>
+      </div>
+
       <div className={cx("flex-row", sliderRow)}>
         <div className="flex-col" style={{ justifyContent: "flex-end" }}>
           <label className={switchControl}>
             <input
               type="checkbox"
-              onInput={(e) => {
-                const checked = (e.target as HTMLInputElement).checked;
-                setVoicesBackgroundMode(checked);
-              }}
+              checked={voicesOn}
+              onChange={(e) => setVoicesBackgroundMode(e.target.checked)}
             />
             <span className={cx(slider, round, "slider", "round")}></span>
           </label>
@@ -194,10 +230,8 @@ export const EffectsPanel = () => {
           <label className={switchControl}>
             <input
               type="checkbox"
-              onInput={(e) => {
-                const checked = (e.target as HTMLInputElement).checked;
-                setBackgroundMode(checked);
-              }}
+              checked={backgroundMode}
+              onChange={(e) => setBackgroundMode(e.target.checked)}
             />
             <span className={cx(slider, round, "slider", "round")}></span>
           </label>
@@ -208,8 +242,6 @@ export const EffectsPanel = () => {
           </span>
         </div>
       </div>
-      <h2 id="effects-controls-row" className={effectsControlsRow}>Visuals</h2>
-      <p>Pause visuals to improve performance and save power.</p>
 
       <div className={cx("flex-row", sliderRow)}>
         <div className="flex-col" style={{ justifyContent: "flex-end" }}>
@@ -231,19 +263,61 @@ export const EffectsPanel = () => {
         </div>
       </div>
 
-      <div
-        id="effects-controls-row"
-        className={cx("flex-row", effectsControlsRow)}
-        style={{ justifyContent: "space-between" }}
-      >
-        <div className="flex-col">
-          <h2>Effects</h2>
-        </div>
-        <div className="flex-col">
-          {backgroundMode && <p className="hot-green">background mode: on</p>}
-        </div>
+      <div className="flex-row">
+        <h3 className={sliderLabel}>time warp</h3>
+      </div>
+      <div className="flex-row">
+        <CanvasSlider
+          id="time-warp"
+          value={timeWarpValue}
+          handleValue={handleTimeWarp}
+        />
+      </div>
+      <div className="flex-row">
+        <h3 className={sliderLabel}>energy</h3>
+      </div>
+      <div className="flex-row">
+        <CanvasSlider
+          id="energy"
+          value={energyValue}
+          handleValue={handleEnergy}
+        />
       </div>
 
+      <div className="flex-row">
+        <h3 className={sliderLabel}>— fine tune —</h3>
+      </div>
+      <div className="flex-row">
+        <h3 className={sliderLabel}>highpass filter</h3>
+      </div>
+      <div className="flex-row">
+        <CanvasSlider
+          id="hp-filter"
+          value={hpValue}
+          handleValue={(v) => setHpValue(v)}
+        />
+      </div>
+      <div className="flex-row">
+        <h3 className={sliderLabel}>lowpass filter</h3>
+      </div>
+      <div className="flex-row">
+        <CanvasSlider
+          id="lp-filter"
+          value={lpValue}
+          handleValue={(v) => setLpValue(v)}
+          reverse={true}
+        />
+      </div>
+      <div className="flex-row">
+        <h3 className={sliderLabel}>ambience</h3>
+      </div>
+      <div className="flex-row">
+        <CanvasSlider
+          id="ambience"
+          handleValue={(v) => setAmValue(v)}
+          value={amValue}
+        />
+      </div>
       <div className="flex-row">
         <button
           className={cx(buttonWhite, groupedButtons)}
@@ -277,58 +351,6 @@ export const EffectsPanel = () => {
         >
           Randomize
         </button>
-      </div>
-
-      <div className="flex-row">
-        <h3 className={sliderLabel}>time warp</h3>
-      </div>
-      <div className="flex-row">
-        <CanvasSlider
-          id="time-warp"
-          value={timeWarpValue}
-          handleValue={handleTimeWarp}
-        />
-      </div>
-      <div className="flex-row">
-        <h3 className={sliderLabel}>energy</h3>
-      </div>
-      <div className="flex-row">
-        <CanvasSlider
-          id="energy"
-          value={energyValue}
-          handleValue={handleEnergy}
-        />
-      </div>
-      <div className="flex-row">
-        <h3 className={sliderLabel}>highpass filter</h3>
-      </div>
-      <div className="flex-row">
-        <CanvasSlider
-          id="hp-filter"
-          value={hpValue}
-          handleValue={(v) => setHpValue(v)}
-        />
-      </div>
-      <div className="flex-row">
-        <h3 className={sliderLabel}>lowpass filter</h3>
-      </div>
-      <div className="flex-row">
-        <CanvasSlider
-          id="lp-filter"
-          value={lpValue}
-          handleValue={(v) => setLpValue(v)}
-          reverse={true}
-        />
-      </div>
-      <div className="flex-row">
-        <h3 className={sliderLabel}>ambience</h3>
-      </div>
-      <div className="flex-row">
-        <CanvasSlider
-          id="ambience"
-          handleValue={(v) => setAmValue(v)}
-          value={amValue}
-        />
       </div>
     </div>
   );

--- a/src/components/EffectsPanel.tsx
+++ b/src/components/EffectsPanel.tsx
@@ -42,7 +42,8 @@ export const EffectsPanel = () => {
     (s) => s.setBackgroundMode
   );
   const setPauseVisuals = useMusicPlayerStore((s) => s.setPauseVisuals);
-  const { bpm } = useContext(SongContext)!;
+  const setDrift = useMusicPlayerStore((s) => s.setDrift);
+  const { bpm, id } = useContext(SongContext)!;
   const { WAW } = useContext(WebAudioContext)!;
 
   const [backgroundMode, setBackgroundMode] = useState(false);
@@ -51,6 +52,8 @@ export const EffectsPanel = () => {
   const [hpValue, setHpValue] = useState(1);
   const [lpValue, setLpValue] = useState(100);
   const [amValue, setAmValue] = useState(1);
+  const [driftValue, setDriftValue] = useState(1);
+  const driftGlideRef = useRef<number | null>(null);
 
   const effectsTargets = useRef<{
     time: number | null;
@@ -125,6 +128,28 @@ export const EffectsPanel = () => {
   useEffect(() => {
     WAW.setEffects("am", amValue);
   }, [WAW, amValue]);
+
+  // slider 1..100 -> rate 1.0..0.5 (one octave / half tempo at the floor)
+  const driftToRate = (v: number) => 1 - ((v - 1) / 99) * 0.5;
+
+  const handleDrift = (v: number) => {
+    setDriftValue(v);
+    setDrift((v - 1) / 99);
+    const targetRate = driftToRate(v);
+    const startRate = WAW.getTempoClock(id).currentRate;
+    const steps = 20;
+    let i = 0;
+    if (driftGlideRef.current) window.clearInterval(driftGlideRef.current);
+    driftGlideRef.current = window.setInterval(() => {
+      i++;
+      const r = startRate + (targetRate - startRate) * (i / steps);
+      WAW.setDriftRate(id, r);
+      if (i >= steps) {
+        window.clearInterval(driftGlideRef.current!);
+        driftGlideRef.current = null;
+      }
+    }, 30);
+  };
 
   return (
     <div id="effects-panel" className={flexPanel}>
@@ -242,6 +267,12 @@ export const EffectsPanel = () => {
         </button>
       </div>
 
+      <div className="flex-row">
+        <h3 className={sliderLabel}>drift</h3>
+      </div>
+      <div className="flex-row">
+        <CanvasSlider id="drift" value={driftValue} handleValue={handleDrift} />
+      </div>
       <div className="flex-row">
         <h3 className={sliderLabel}>highpass filter</h3>
       </div>

--- a/src/components/EffectsPanel.tsx
+++ b/src/components/EffectsPanel.tsx
@@ -32,9 +32,15 @@ const EFFECT_TICK_BEATS = 0.25;
 const HP_WALK_CEIL = 72;
 const LP_WALK_FLOOR = 55;
 
+// The edge-avoidance margin (bounds) and step size (effectSize) were tuned on
+// the full 1-100 range as 35 and 40; they scale with the actual range so a
+// narrowed safe zone (e.g. the background-mode lp walk, 55-100) wanders the same
+// way. With the fixed values, the middle "gentle wander" branch is unreachable
+// in a narrow range and the walk just ratchets between the bounds.
 const chooseNewValue = (prev: number, min = 1, max = 100): number => {
-  const bounds = 35;
-  const effectSize = 40;
+  const range = max - min;
+  const bounds = (35 / 99) * range;
+  const effectSize = (40 / 99) * range;
   let newValue: number;
   if (prev < min + bounds) {
     newValue = prev + Math.random() * effectSize;

--- a/src/components/EffectsPanel.tsx
+++ b/src/components/EffectsPanel.tsx
@@ -22,19 +22,24 @@ import { cx } from "../utils/cx";
 
 const EFFECT_INTERVAL = 4; // in beats
 
-const chooseNewValue = (prev: number): number => {
-  const max = 100;
+// Background-mode safe zone for the effect walk so it can never bury the song:
+// the highpass stays <= ~1 kHz (value 72) and the lowpass >= ~3 kHz (value 55).
+// Manual sliders are unconstrained — only the auto-walk is penned.
+const HP_WALK_CEIL = 72;
+const LP_WALK_FLOOR = 55;
+
+const chooseNewValue = (prev: number, min = 1, max = 100): number => {
   const bounds = 35;
   const effectSize = 40;
   let newValue: number;
-  if (prev < bounds) {
+  if (prev < min + bounds) {
     newValue = prev + Math.random() * effectSize;
   } else if (prev > max - bounds) {
     newValue = prev - Math.random() * effectSize;
   } else {
     newValue = prev + (-0.5 + Math.random()) * effectSize;
   }
-  return clamp(newValue, 1, 100);
+  return clamp(newValue, min, max);
 };
 
 export const EffectsPanel = () => {
@@ -77,8 +82,8 @@ export const EffectsPanel = () => {
     ) {
       // set new targets
       effectsTargets.current.time = WAW.audioCtx.currentTime;
-      effectsTargets.current.hp = chooseNewValue(hpValue);
-      effectsTargets.current.lp = chooseNewValue(lpValue);
+      effectsTargets.current.hp = chooseNewValue(hpValue, 1, HP_WALK_CEIL);
+      effectsTargets.current.lp = chooseNewValue(lpValue, LP_WALK_FLOOR, 100);
       effectsTargets.current.am = chooseNewValue(amValue);
     }
     const progress =

--- a/src/components/EffectsPanel.tsx
+++ b/src/components/EffectsPanel.tsx
@@ -160,6 +160,18 @@ export const EffectsPanel = () => {
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [bpm, backgroundMode, triggerRandomEffects]);
 
+  /* Glide Cleanup Hook */
+  // kill an in-flight glide when the song changes or the panel unmounts, so the
+  // interval can't keep firing against a stale song id
+  useEffect(() => {
+    return () => {
+      if (timeWarpGlideRef.current) {
+        window.clearInterval(timeWarpGlideRef.current);
+        timeWarpGlideRef.current = null;
+      }
+    };
+  }, [id]);
+
   /* Effect Value Hooks */
   useEffect(() => {
     WAW.setEffects("hp", hpValue);

--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -12,6 +12,21 @@ import { TestingContext } from "../contexts/contexts";
 import { WebAudioContext } from "../contexts/contexts";
 import { useMusicPlayerStore } from "../stores/musicPlayerStore";
 import { nextSubdivision } from "../utils/audioUtils";
+import { lerp } from "../utils/mathUtils";
+
+/*
+ * Energy drives the background-mode voice loop, modulating two things: the target
+ * number of active voices and the variability rate. The loop ticks every
+ * VOICE_TICK_BEATS; when off target it steps one voice toward it, and once at
+ * target it occasionally swaps a voice (random out, random in) at a mean spacing
+ * that Energy scales from very slow (calm) to brisk (lively). Voice selection is
+ * random — no per-group weighting.
+ */
+const VOICE_TICK_BEATS = 8;
+const MIN_VOICES = 2; // target at the calm end
+const MAX_VOICE_FRACTION = 0.75; // target at the lively end, as a fraction of the scene
+const CALM_SWAP_BEATS = 320; // mean beats between swaps at lowest Energy
+const LIVELY_SWAP_BEATS = 48; // ...and at highest Energy
 
 export const MusicPlayer = () => {
   const { flags } = useContext(TestingContext)!;
@@ -40,6 +55,7 @@ export const MusicPlayer = () => {
   const randomizeCallbacks = useMusicPlayerStore((s) => s.randomizeCallbacks);
   const voices = useMusicPlayerStore((s) => s.voices);
   const backgroundMode = useMusicPlayerStore((s) => s.backgroundMode);
+  const energy = useMusicPlayerStore((s) => s.energy);
   const mute = useMusicPlayerStore((s) => s.mute);
 
   useEffect(() => {
@@ -97,22 +113,29 @@ export const MusicPlayer = () => {
     const viable = voices.filter((v) => !v.voiceState.includes("pending"));
     if (viable.length === 0) return;
 
-    const first = viable[Math.floor(Math.random() * viable.length)];
-    first.ref.click();
+    const active = viable.filter((v) => v.voiceState === "active");
+    const stopped = viable.filter((v) => v.voiceState === "stopped");
+    const target = Math.max(
+      1,
+      Math.round(lerp(MIN_VOICES, MAX_VOICE_FRACTION * voices.length, energy))
+    );
 
-    // When fewer than half the voices are active, also trigger a second voice
-    // from a different group to build the mix up.
-    const activeCount = voices.filter((v) => v.voiceState === "active").length;
-    if (activeCount < voices.length / 2) {
-      const viableTwo = viable.filter(
-        (v) => v.id !== first.id && v.group !== first.group
-      );
-      if (viableTwo.length > 0) {
-        const second = viableTwo[Math.floor(Math.random() * viableTwo.length)];
-        second.ref.click();
+    const pick = (list: typeof viable) =>
+      list[Math.floor(Math.random() * list.length)];
+
+    if (active.length < target && stopped.length) {
+      pick(stopped).ref.click();
+    } else if (active.length > target) {
+      pick(active).ref.click();
+    } else if (stopped.length && active.length) {
+      // at target: occasionally swap one voice for slow variability
+      const swapBeats = lerp(CALM_SWAP_BEATS, LIVELY_SWAP_BEATS, energy);
+      if (Math.random() < VOICE_TICK_BEATS / swapBeats) {
+        pick(active).ref.click();
+        pick(stopped).ref.click();
       }
     }
-  }, [voices]);
+  }, [voices, energy]);
 
   /* Background Mode Hook */
   useEffect(() => {
@@ -123,7 +146,7 @@ export const MusicPlayer = () => {
     ) {
       backgroundModeEventRef.current = WAW.scheduler.scheduleRepeating(
         WAW.audioCtx.currentTime + 60 / bpm,
-        (32 * 60) / bpm,
+        (VOICE_TICK_BEATS * 60) / bpm,
         triggerRandomVoice
       );
       // triggerRandomVoice updates when different voices are on

--- a/src/components/toggle-button/ToggleButton.tsx
+++ b/src/components/toggle-button/ToggleButton.tsx
@@ -47,7 +47,9 @@ export const ToggleButton = (props: Props) => {
 
   const changeVoiceState = useCallback(
     (newState: VoiceState) => {
-      // cancel current event for this toggle (necessary to stop a pending start)
+      // drop any pending boundary commit + status change for this toggle
+      // (necessary to stop a pending start)
+      WAW.cancelBoundary(name);
       scheduler.cancel(animationEventRef.current);
 
       const initialState: VoiceState =
@@ -56,38 +58,35 @@ export const ToggleButton = (props: Props) => {
       updateVoiceState({ id: name, newState: initialState });
       queueVoice(groupName, name, initialState);
 
-      // calculate time till next loop start
-      const quantizedStartSeconds = tempoClock.nextBoundary(
+      // predicted boundary drives only the visual countdown; the audio start/stop
+      // and the status change commit against the live clock at the boundary, so a
+      // Drift change before then can't bring the voice in off-grid or off-pitch.
+      const predictedSeconds = tempoClock.nextBoundary(
         quantizedStartBeats,
         audioCtx.currentTime
       );
-
-      switch (newState) {
-        case "active":
-          player.start(quantizedStartSeconds);
-          break;
-        case "stopped":
-          player.stop(quantizedStartSeconds);
-          break;
-        default:
-          break;
-      }
-
-      // schedule a status change
-      animationEventRef.current = scheduler.scheduleOnce(
-        quantizedStartSeconds,
-        () => {
-          updateVoiceState({ id: name, newState });
-        }
-      ) as number;
-
-      // convert to millis for animations
-      const quantizedStartMillis =
-        (quantizedStartSeconds - audioCtx.currentTime) * 1000;
       const animationType = newState === "stopped" ? "stop" : "start";
-      viewRef.current!.runAnimation(animationType, quantizedStartMillis);
+      viewRef.current!.runAnimation(
+        animationType,
+        (predictedSeconds - audioCtx.currentTime) * 1000
+      );
+
+      const action = newState === "active" ? "start" : "stop";
+      WAW.scheduleAtBoundary(
+        name,
+        player,
+        tempoClock,
+        quantizedStartBeats,
+        action,
+        (time) => {
+          animationEventRef.current = scheduler.scheduleOnce(time, () => {
+            updateVoiceState({ id: name, newState });
+          }) as number;
+        }
+      );
     },
     [
+      WAW,
       scheduler,
       name,
       audioCtx,
@@ -126,11 +125,12 @@ export const ToggleButton = (props: Props) => {
   useEffect(() => {
     if (player) {
       return () => {
+        WAW.cancelBoundary(name);
         player.stop();
         player.disconnect();
       };
     }
-  }, [player]);
+  }, [WAW, name, player]);
 
   return (
     <ToggleButtonView

--- a/src/components/toggle-button/ToggleButton.tsx
+++ b/src/components/toggle-button/ToggleButton.tsx
@@ -60,7 +60,7 @@ export const ToggleButton = (props: Props) => {
 
       // predicted boundary drives only the visual countdown; the audio start/stop
       // and the status change commit against the live clock at the boundary, so a
-      // Drift change before then can't bring the voice in off-grid or off-pitch.
+      // Time Warp change before then can't bring the voice in off-grid or off-pitch.
       const predictedSeconds = tempoClock.nextBoundary(
         quantizedStartBeats,
         audioCtx.currentTime

--- a/src/components/toggle-button/ToggleButton.tsx
+++ b/src/components/toggle-button/ToggleButton.tsx
@@ -4,7 +4,6 @@ import { TestingContext } from "../../contexts/contexts";
 import { WebAudioContext } from "../../contexts/contexts";
 import { useMusicPlayerStore, VoiceState } from "../../stores/musicPlayerStore";
 import { MusicalDuration } from "../../contexts/contexts";
-import { nextSubdivision } from "../../utils/audioUtils";
 import {
   ToggleButtonView,
   ToggleButtonViewHandle,
@@ -22,7 +21,7 @@ export const ToggleButton = (props: Props) => {
   const animationEventRef = useRef<number | undefined>(undefined);
 
   const { WAW } = useContext(WebAudioContext)!;
-  const { id, timeSignature, bpm } = useContext(SongContext)!;
+  const { id, timeSignature } = useContext(SongContext)!;
   const { flags } = useContext(TestingContext)!;
   const { name, groupName, quantizeLength } = props;
   const addVoice = useMusicPlayerStore((s) => s.addVoice);
@@ -40,6 +39,7 @@ export const ToggleButton = (props: Props) => {
 
   const { scheduler, audioCtx } = WAW;
   const player = WAW.getVoices(id)[name];
+  const tempoClock = WAW.getTempoClock(id);
 
   const quantizedStartBeats = flags.quantizeSamples
     ? timeSignature * parseInt(quantizeLength!)
@@ -57,10 +57,9 @@ export const ToggleButton = (props: Props) => {
       queueVoice(groupName, name, initialState);
 
       // calculate time till next loop start
-      const quantizedStartSeconds = nextSubdivision(
-        audioCtx,
-        bpm,
-        quantizedStartBeats
+      const quantizedStartSeconds = tempoClock.nextBoundary(
+        quantizedStartBeats,
+        audioCtx.currentTime
       );
 
       switch (newState) {
@@ -92,7 +91,7 @@ export const ToggleButton = (props: Props) => {
       scheduler,
       name,
       audioCtx,
-      bpm,
+      tempoClock,
       quantizedStartBeats,
       player,
       updateVoiceState,

--- a/src/components/toggle-button/ToggleButton.tsx
+++ b/src/components/toggle-button/ToggleButton.tsx
@@ -58,9 +58,12 @@ export const ToggleButton = (props: Props) => {
       updateVoiceState({ id: name, newState: initialState });
       queueVoice(groupName, name, initialState);
 
-      // predicted boundary drives only the visual countdown; the audio start/stop
-      // and the status change commit against the live clock at the boundary, so a
-      // Time Warp change before then can't bring the voice in off-grid or off-pitch.
+      // the predicted boundary only seeds the visual countdown; the audio
+      // start/stop and the status change commit against the live clock at the
+      // boundary, so a Time Warp change before then can't bring the voice in
+      // off-grid or off-pitch. onRetime (below) rescales the countdown whenever
+      // a rate change moves the boundary, so it ends when the voice actually
+      // starts.
       const predictedSeconds = tempoClock.nextBoundary(
         quantizedStartBeats,
         audioCtx.currentTime
@@ -82,7 +85,11 @@ export const ToggleButton = (props: Props) => {
           animationEventRef.current = scheduler.scheduleOnce(time, () => {
             updateVoiceState({ id: name, newState });
           }) as number;
-        }
+        },
+        (time) =>
+          viewRef.current!.retimeAnimation(
+            (time - audioCtx.currentTime) * 1000
+          )
       );
     },
     [

--- a/src/components/toggle-button/ToggleButtonView.tsx
+++ b/src/components/toggle-button/ToggleButtonView.tsx
@@ -25,6 +25,11 @@ const STOP_PARAMS = {
 
 export interface ToggleButtonViewHandle {
   runAnimation: (type: "start" | "stop", durationMs: number) => void;
+  /**
+   * Rescale any in-flight toggle animation to finish in `remainingMs` — called
+   * when a Time Warp change moves the pending commit's boundary time.
+   */
+  retimeAnimation: (remainingMs: number) => void;
   getButton: () => HTMLButtonElement | null;
 }
 
@@ -55,6 +60,23 @@ export const ToggleButtonView = ({ initialActive, onClick, ref }: Props) => {
     ref,
     () => ({
       getButton: () => buttonRef.current,
+      retimeAnimation: (remainingMs) => {
+        const remaining = Math.max(remainingMs, 1) / 1000;
+        const iconDiv = iconDivRef.current!;
+        const targets = [
+          circleRef.current!,
+          iconPolyRef.current!,
+          iconDiv,
+          ...iconDiv.children,
+          buttonRef.current!,
+        ];
+        // timeScale rescales a tween's remaining local time onto the new real
+        // remaining time, preserving each tween's ease and end values.
+        gsap.getTweensOf(targets).forEach((tween) => {
+          const left = tween.duration() - tween.time();
+          if (left > 0) tween.timeScale(left / remaining);
+        });
+      },
       runAnimation: (type, durationMs) => {
         const seconds = durationMs / 1000;
         const circleSvg = circleRef.current!;

--- a/src/stores/musicPlayerStore.ts
+++ b/src/stores/musicPlayerStore.ts
@@ -40,10 +40,12 @@ interface MusicPlayerState {
   randomizeCallbacks: NamedCallback[];
   backgroundMode: boolean;
   timeWarp: number;
+  energy: number;
   pauseVisuals: boolean;
   mute: boolean;
   setBackgroundMode: (v: boolean) => void;
   setTimeWarp: (v: number) => void;
+  setEnergy: (v: number) => void;
   setPauseVisuals: (v: boolean) => void;
   startMute: () => void;
   stopMute: () => void;
@@ -72,6 +74,7 @@ const initialState = {
   randomizeCallbacks: [],
   backgroundMode: false,
   timeWarp: 0,
+  energy: 0.5,
   pauseVisuals: false,
   mute: false,
 };
@@ -80,6 +83,7 @@ export const useMusicPlayerStore = create<MusicPlayerState>()((set) => ({
   ...initialState,
   setBackgroundMode: (v) => set({ backgroundMode: v }),
   setTimeWarp: (v) => set({ timeWarp: v }),
+  setEnergy: (v) => set({ energy: v }),
   setPauseVisuals: (v) => set({ pauseVisuals: v }),
   startMute: () => set({ mute: true }),
   stopMute: () => set({ mute: false }),

--- a/src/stores/musicPlayerStore.ts
+++ b/src/stores/musicPlayerStore.ts
@@ -39,11 +39,11 @@ interface MusicPlayerState {
   resetCallbacks: NamedCallback[];
   randomizeCallbacks: NamedCallback[];
   backgroundMode: boolean;
-  drift: number;
+  timeWarp: number;
   pauseVisuals: boolean;
   mute: boolean;
   setBackgroundMode: (v: boolean) => void;
-  setDrift: (v: number) => void;
+  setTimeWarp: (v: number) => void;
   setPauseVisuals: (v: boolean) => void;
   startMute: () => void;
   stopMute: () => void;
@@ -71,7 +71,7 @@ const initialState = {
   resetCallbacks: [],
   randomizeCallbacks: [],
   backgroundMode: false,
-  drift: 0,
+  timeWarp: 0,
   pauseVisuals: false,
   mute: false,
 };
@@ -79,7 +79,7 @@ const initialState = {
 export const useMusicPlayerStore = create<MusicPlayerState>()((set) => ({
   ...initialState,
   setBackgroundMode: (v) => set({ backgroundMode: v }),
-  setDrift: (v) => set({ drift: v }),
+  setTimeWarp: (v) => set({ timeWarp: v }),
   setPauseVisuals: (v) => set({ pauseVisuals: v }),
   startMute: () => set({ mute: true }),
   stopMute: () => set({ mute: false }),

--- a/src/stores/musicPlayerStore.ts
+++ b/src/stores/musicPlayerStore.ts
@@ -39,9 +39,11 @@ interface MusicPlayerState {
   resetCallbacks: NamedCallback[];
   randomizeCallbacks: NamedCallback[];
   backgroundMode: boolean;
+  drift: number;
   pauseVisuals: boolean;
   mute: boolean;
   setBackgroundMode: (v: boolean) => void;
+  setDrift: (v: number) => void;
   setPauseVisuals: (v: boolean) => void;
   startMute: () => void;
   stopMute: () => void;
@@ -69,6 +71,7 @@ const initialState = {
   resetCallbacks: [],
   randomizeCallbacks: [],
   backgroundMode: false,
+  drift: 0,
   pauseVisuals: false,
   mute: false,
 };
@@ -76,6 +79,7 @@ const initialState = {
 export const useMusicPlayerStore = create<MusicPlayerState>()((set) => ({
   ...initialState,
   setBackgroundMode: (v) => set({ backgroundMode: v }),
+  setDrift: (v) => set({ drift: v }),
   setPauseVisuals: (v) => set({ pauseVisuals: v }),
   startMute: () => set({ mute: true }),
   stopMute: () => set({ mute: false }),


### PR DESCRIPTION
Layer 1 of the background-mode v2 vision ([issue #80](https://github.com/mracette/soundscape/issues/80)). Journeys (timed sleep/nap/meditation arcs) will follow in a separate PR.

## Why
Background-mode effects — especially the highpass on Mornings — could climb high enough to make songs hard to hear (reported by a listener). More broadly, background mode had no expressive controls; it just churned voices and effects on fixed timers, and the churn was too fast. This makes background mode never degrade audibility and gives it two musical knobs.

## What
- **Time Warp** — one knob that slows tempo and drops pitch together (down to 0.5×), staying sample-accurate and phase-locked via a new variable-rate `TempoClock` and a look-ahead boundary scheduler.
- **Energy** — one knob folding voice density (target active voices) and variability (how often voices swap), much calmer than the old fixed churn.
- **Audibility fix** — the effect random-walk is penned to a safe zone in background mode (highpass ≤ ~1 kHz, lowpass ≥ ~3 kHz) so it can never bury the song; manual sliders keep full range.
- **Effect pacing** — the effect modulation cadence and transitions now scale with Energy and are much slower than before.
- **Presets** — a Work → Ambient → Sleep spectrum; one click applies a Time Warp/Energy/ambience snapshot and turns background mode on.
- **Panel** — reorganized: presets, toggles, knobs, then a "fine tune" section for the filters; Reset/Randomize disabled while the effects walk runs.

## Impact
- Background mode is audibly gentler and never buries the song.
- New \`TempoClock\` class + look-ahead scheduling in \`WebAudioWrapper\`; voice starts now quantize through it. Behavior is identical to today when Time Warp is off.
- No dependency changes. No unit tests added (Vitest is coming on a separate branch); verified via typecheck/lint/build and by ear.

## Design notes
- Time Warp and Energy are intentionally independent knobs — Journeys (Layer 2) will animate both over time, which gives more control than auto-coupling them.
- The "Sleep" preset is a static deep-calm snapshot, distinct from the future Sleep Journey arc.