### PR TITLE
Fix confirmed findings from the overhaul adversarial review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master, 2026-overhaul, quality]
+    branches: [master, dev]
   pull_request:
 concurrency:
   group: ci-${{ github.ref }}
@@ -18,6 +18,9 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
+      # Production-build-only breakage (vanilla-extract plugin, env handling)
+      # isn't caught by typecheck or the vite dev server the e2e suite runs on.
+      - run: pnpm build
       - run: pnpm exec eslint src/
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm test:e2e

--- a/e2e/routing.spec.js
+++ b/e2e/routing.spec.js
@@ -44,5 +44,10 @@ test("an unknown song id redirects to the landing page", async ({ page }) => {
   await page.goto("/play/bogus", { waitUntil: "domcontentloaded" });
   await expect(page).toHaveURL(/\/$/);
   await expect(page.locator("#landing-page-canvas")).toBeAttached();
+  // The redirect must replace the bad entry rather than push on top of it —
+  // otherwise Back returns to /play/bogus and re-triggers the redirect forever.
+  // Baseline is 2 (the initial about:blank entry + this navigation); a pushed
+  // redirect would make it 3.
+  expect(await page.evaluate(() => history.length)).toBe(2);
   expect(pageErrors.map((e) => e.message).join("\n")).toBe("");
 });

--- a/src/classes/Analyser.ts
+++ b/src/classes/Analyser.ts
@@ -16,7 +16,6 @@ interface AnalyserParams {
   xExponent?: number;
   yExponent?: number;
   binMethod?: string;
-  [key: string]: unknown;
 }
 
 // split analyser holds left/right AnalyserNode pair; non-split holds a single AnalyserNode

--- a/src/classes/Analyser.ts
+++ b/src/classes/Analyser.ts
@@ -275,10 +275,13 @@ export class Analyser {
   getFrequencyBins(channel?: string): { data: number; freq: number }[] {
     const fBins: { data: number; freq: number }[] = [];
     this.getFrequencyData(channel);
-    const data = (this.fftData as Uint8Array<ArrayBuffer>).slice(
-      this.binMin,
-      this.binMax + 1
-    );
+    // Same channel semantics as getFrequencyData: split analysers store
+    // {left, right}, so slice the requested channel's array.
+    const source =
+      channel === "left" || channel === "right"
+        ? (this.fftData as SplitUint8)[channel]
+        : (this.fftData as Uint8Array<ArrayBuffer>);
+    const data = source.slice(this.binMin, this.binMax + 1);
 
     data.forEach((d: number, i: number) => {
       fBins.push({

--- a/src/classes/WebAudioWrapper.ts
+++ b/src/classes/WebAudioWrapper.ts
@@ -283,7 +283,7 @@ export class WebAudioWrapper {
             power: 6,
             minDecibels: -120,
             maxDecibels: 0,
-            smoothingTimeConstanct: 0.25,
+            smoothingTimeConstant: 0.25,
           }
         );
         this.nodes.analysers = analysers;

--- a/src/components/AppRouter.tsx
+++ b/src/components/AppRouter.tsx
@@ -23,7 +23,7 @@ export const AppRouter = (props: Props) => {
           const songId = params.songId as SongId;
           const song = props.appConfig.find((s) => s.id === songId);
           if (!song) {
-            return <Redirect to="/" />;
+            return <Redirect to="/" replace />;
           }
           return (
             <ThemeContext.Provider

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -81,7 +81,7 @@ export const LandingPage = (props: LandingPageProps) => {
               <InfoPageInner />
             </Route>
             <Route>
-              <Redirect to="/" />
+              <Redirect to="/" replace />
             </Route>
           </Switch>
         </div>

--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -44,9 +44,14 @@ export const MusicPlayer = () => {
 
   useEffect(() => {
     if (wawLoadStatus && !songLoadStatus) {
-      WAW.initSongState(id).then(() => {
-        setSongLoadStatus(true);
-      });
+      WAW.initSongState(id)
+        .then(() => {
+          setSongLoadStatus(true);
+        })
+        .catch((err) => {
+          // no error UI — the loading screen stays up, but the cause is visible
+          console.error("Failed to initialize song audio:", err);
+        });
     }
 
     // safe to resume and take the init time here (after user gesture)

--- a/src/components/toggle-button/ToggleButtonView.tsx
+++ b/src/components/toggle-button/ToggleButtonView.tsx
@@ -2,6 +2,7 @@ import {
   useRef,
   useState,
   useContext,
+  useEffect,
   useImperativeHandle,
   type Ref,
 } from "react";
@@ -51,6 +52,27 @@ export const ToggleButtonView = ({ initialActive, onClick, ref }: Props) => {
   // from under gsap, snapping or flashing the ring instead of letting it animate.
   const [restingActive] = useState(initialActive);
 
+  const circumference = 2 * Math.PI * (buttonRadius - buttonBorder / 2);
+  // Latest geometry for gsap callbacks, which capture values at tween creation.
+  const circumferenceRef = useRef(circumference);
+  // The state the ring rests at once tweens settle — active means full offset.
+  const restingActiveRef = useRef(initialActive);
+
+  // Because gsap owns strokeDashoffset (see restingActive above), React never
+  // rewrites it — but the "active" resting value depends on the circumference,
+  // which changes with the viewport. On resize, rewrite the DOM value to the
+  // new circumference when the ring is resting active; mid-sweep, the start
+  // tween's onComplete settles it instead.
+  useEffect(() => {
+    const prev = circumferenceRef.current;
+    circumferenceRef.current = circumference;
+    const circleSvg = circleRef.current;
+    if (!circleSvg || prev === circumference) return;
+    if (restingActiveRef.current && !gsap.isTweening(circleSvg)) {
+      gsap.set(circleSvg, { strokeDashoffset: circumference });
+    }
+  }, [circumference]);
+
   useImperativeHandle(
     ref,
     () => ({
@@ -73,6 +95,8 @@ export const ToggleButtonView = ({ initialActive, onClick, ref }: Props) => {
         let backgroundColor: string;
         let rotateZ: number;
 
+        restingActiveRef.current = type === "start";
+
         if (type === "start") {
           rotateZ = -180;
           backgroundColor = START_PARAMS.backgroundColor;
@@ -86,6 +110,13 @@ export const ToggleButtonView = ({ initialActive, onClick, ref }: Props) => {
               strokeDashoffset: 2 * Math.PI * (buttonRadius - buttonBorder / 2),
               duration: seconds,
               ease: "none",
+              // settle to the latest circumference — a resize mid-sweep would
+              // otherwise leave the ring at the stale pre-resize target
+              onComplete: () => {
+                gsap.set(circleSvg, {
+                  strokeDashoffset: circumferenceRef.current,
+                });
+              },
             }
           );
         } else {

--- a/src/utils/audioUtils.ts
+++ b/src/utils/audioUtils.ts
@@ -88,6 +88,14 @@ export const loadArrayBuffer = (audioFilePath: string): Promise<ArrayBuffer> => 
     request.addEventListener("load", () => {
       if (request.status === 200) {
         resolve(request.response as ArrayBuffer);
+      } else {
+        // 'load' also fires on 404/503 — without this reject the promise
+        // never settles and the loading screen hangs silently
+        reject(
+          new Error(
+            `Failed to load audio (HTTP ${request.status}): ${audioFilePath}`
+          )
+        );
       }
     });
     request.addEventListener("error", (err) => {

--- a/src/viz/SceneManager.ts
+++ b/src/viz/SceneManager.ts
@@ -101,6 +101,11 @@ export class SceneManager {
   // Animation frame handle
   protected currentFrame!: number;
 
+  // Set by dispose(). Subclasses start the RAF loop from async asset-load
+  // continuations (`Promise.all(...).then(() => super.animate())`) that
+  // dispose() cannot cancel — this flag lets animate() refuse to (re)start.
+  protected disposed = false;
+
   constructor(canvas: HTMLCanvasElement) {
     const opts = {
       songId: null,
@@ -160,6 +165,7 @@ export class SceneManager {
    * dispose the renderer's too — deterministic release rather than waiting for GC.
    */
   dispose() {
+    this.disposed = true;
     this.stop();
     this.disposeAll(this.scene);
     this.renderer.dispose();
@@ -242,6 +248,10 @@ export class SceneManager {
    * `requestAnimationFrame`.
    */
   animate() {
+    // Guards both the pending re-queue after dispose() and a post-dispose loop
+    // start from a scene's async setup — either would pin the disposed
+    // renderer/canvas/GL context in a RAF loop forever.
+    if (this.disposed) return;
     this.currentFrame = requestAnimationFrame(this.animate);
 
     // Frame-rate cap: skip this tick unless ~1/60s (minus a jitter margin) has

--- a/src/viz/SceneManager.ts
+++ b/src/viz/SceneManager.ts
@@ -245,10 +245,16 @@ export class SceneManager {
     this.currentFrame = requestAnimationFrame(this.animate);
 
     // Frame-rate cap: skip this tick unless ~1/60s (minus a jitter margin) has
-    // elapsed since the last rendered frame.
+    // elapsed since the last rendered frame. Advance the accumulator by the
+    // exact interval rather than snapping to `now`, so the remainder carries
+    // over — snapping quantizes the rate to refresh/ceil(interval/period),
+    // e.g. 90Hz→45fps, 144Hz→72fps, 165Hz→55fps.
     const now = performance.now();
     if (now - this.lastFrameTime < FRAME_INTERVAL_MS - FRAME_TOLERANCE_MS) return;
-    this.lastFrameTime = now;
+    this.lastFrameTime += FRAME_INTERVAL_MS;
+    // Drift clamp: after a stall (hidden tab, long GC pause) the accumulator
+    // sits far in the past and would render every tick to "catch up" — resync.
+    if (now - this.lastFrameTime > 2 * FRAME_INTERVAL_MS) this.lastFrameTime = now;
 
     this.showStats && this.helpers.stats?.begin();
     this.telemetry?.beginFrame();

--- a/src/viz/SceneManager.ts
+++ b/src/viz/SceneManager.ts
@@ -86,6 +86,9 @@ export class SceneManager {
   protected fpcControl!: boolean;
   protected telemetry?: FrameTelemetry;
   protected perfPanels?: { cpu: StatsPanel; gpu: StatsPanel };
+  // The object published on window.__perf — kept so dispose() can tell whether
+  // the global still points at this instance before clearing it.
+  protected perfHandle?: { snapshot(): TelemetrySnapshot };
   protected lastFrameTime = 0;
 
   // Fields set by init() and subclasses
@@ -121,7 +124,9 @@ export class SceneManager {
         height: null,
       },
       spectrumFunction: (_n: number) => "#FFFFFF",
-      // Perf telemetry + stats overlay opt-in via ?perf=1 (off in production).
+      // Perf telemetry + stats overlay opt-in via ?perf=1. Deliberately works
+      // in production builds (default-off) so real deployments can be profiled
+      // — see docs/superpowers/specs/2026-06-24-perf-telemetry-design.md.
       showStats: new URLSearchParams(window.location.search).has("perf"),
       fpcControl: false,
     };
@@ -149,9 +154,10 @@ export class SceneManager {
       this.telemetry = new FrameTelemetry(
         this.renderer.getContext() as WebGLRenderingContext
       );
-      (window as unknown as { __perf: unknown }).__perf = {
+      this.perfHandle = {
         snapshot: (): TelemetrySnapshot => this.telemetry!.snapshot(),
       };
+      (window as unknown as { __perf: unknown }).__perf = this.perfHandle;
     }
   }
 
@@ -167,6 +173,12 @@ export class SceneManager {
   dispose() {
     this.disposed = true;
     this.stop();
+    // ?perf artifacts outlive the scene unless removed here: the stats overlay
+    // is appended to document.body (a new one per scene switch would stack),
+    // and window.__perf would pin this instance's telemetry + GL context.
+    this.helpers.stats?.dom.remove();
+    const w = window as unknown as { __perf?: unknown };
+    if (this.perfHandle && w.__perf === this.perfHandle) delete w.__perf;
     this.disposeAll(this.scene);
     this.renderer.dispose();
   }
@@ -348,6 +360,9 @@ export class SceneManager {
     };
     if (this.showStats) {
       import("stats.js").then((mod) => {
+        // The import can resolve after dispose() — bail so the overlay never
+        // attaches for a scene that's already been torn down.
+        if (this.disposed) return;
         const Stats = mod.default as unknown as {
           new (): StatsInstance;
           Panel: new (name: string, fg: string, bg: string) => StatsPanel;


### PR DESCRIPTION
Fixes for the findings confirmed by the adversarial review of the 2026 overhaul. One commit per finding; behavior outside these fixes is unchanged.

## Fixed

1. **60fps cap quantized wrongly on non-60Hz displays** — `src/viz/SceneManager.ts:250` — snapping `lastFrameTime = now` discarded the sub-interval remainder (90Hz→45fps, 165Hz→55fps, 144Hz→72fps); now advances the accumulator by the exact interval with a drift clamp. Simulated: 60Hz renders every tick (no 30fps halving regression), 120Hz every other, 90/144/165Hz average ~60.
2. **Disposed scenes restarted an unstoppable RAF loop** — `src/viz/SceneManager.ts:162` — scenes start the loop from async asset-load continuations that `dispose()` can't cancel; a `disposed` flag makes `animate()` refuse to (re)start.
3. **`?perf` helpers leaked across scene switches** — `src/viz/SceneManager.ts` — `dispose()` now removes the stats.js overlay and clears `window.__perf` when it points at this instance; the stats.js dynamic-import continuation bails post-dispose.
4. **Active toggle rings broke on viewport resize** — `src/components/toggle-button/ToggleButtonView.tsx:145` — a resize effect rewrites the DOM `strokeDashoffset` to the new circumference when the ring rests active; the start tween settles to the latest circumference on complete. The 81ce340 flash/snap fix is preserved.
5. **Redirect back-button trap** — `src/components/AppRouter.tsx:26`, `src/components/LandingPage.tsx:84` — both `<Redirect>`s now use `replace`; the unknown-song-id e2e test asserts history depth (verified 2 with replace, 3 without).
6. **CI gaps** — `.github/workflows/ci.yml:4` — push branches updated to `[master, dev]` (2026-overhaul/quality are merged and dead); added `pnpm build` so production-build-only breakage is caught.
7. **`smoothingTimeConstanct` typo** — `src/classes/WebAudioWrapper.ts:286` — premaster analyser silently ran at the 0.8 default; also removed `AnalyserParams`' index signature so future typos fail typecheck (verified no ripples).
8. **`loadArrayBuffer` silent hang on non-200** — `src/utils/audioUtils.ts:88` — rejects with status + url; `MusicPlayer.tsx` logs the failure (no new error UI).
9. **`getFrequencyBins` crash on split analysers** — `src/classes/Analyser.ts:279` — slices the requested channel's array when split, matching `getFrequencyData`'s channel semantics.

## Intentionally not fixed

- **Mornings `getFov` clamp** — approved behavior change, left as is.
- **`?perf` working in prod builds** — by design (default-off; see docs/superpowers/specs/2026-06-24-perf-telemetry-design.md); the stale dev-only comment was corrected instead.

## Verification

`pnpm typecheck`, `pnpm build`, `pnpm exec eslint src/` (0 errors, 9 warnings — identical to the dev baseline), `pnpm test:e2e` (33/33) all green.