### PR TITLE
Add vitest unit layer for the audio core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
+      - run: pnpm test:unit
       # Production-build-only breakage (vanilla-extract plugin, env handling)
       # isn't caught by typecheck or the vite dev server the e2e suite runs on.
       - run: pnpm build

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write src",
+    "test:unit": "vitest run",
     "test:e2e": "PLAYWRIGHT_FORCE_ASYNC_LOADER=1 playwright test"
   },
   "devDependencies": {
@@ -54,7 +55,8 @@
     "prettier": "^3.8.4",
     "typescript": "6.0.3",
     "typescript-eslint": "8.62.0",
-    "vite": "^6.4.3"
+    "vite": "^6.4.3",
+    "vitest": "4.1.9"
   },
   "packageManager": "pnpm@11.8.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       vite:
         specifier: ^6.4.3
         version: 6.4.3(@types/node@26.0.0)(lightningcss@1.32.0)(terser@5.48.0)
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@types/node@26.0.0)(vite@6.4.3(@types/node@26.0.0)(lightningcss@1.32.0)(terser@5.48.0))
 
   apps/desktop:
     dependencies:
@@ -874,6 +877,9 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -900,6 +906,9 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/chroma-js@3.1.2':
     resolution: {integrity: sha512-YBTQqArPN8A0niHXCwrO1z5x++a+6l0mLBykncUpr23oIPW7L4h39s6gokdK/bDrPmSh8+TjMmrhBPnyiaWPmQ==}
 
@@ -914,6 +923,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -1054,6 +1066,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
@@ -1147,6 +1188,10 @@ packages:
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -1262,6 +1307,10 @@ packages:
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1647,6 +1696,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1654,6 +1706,10 @@ packages:
   eval@0.1.8:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
     engines: {node: '>= 0.8'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -2181,6 +2237,9 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   make-fetch-happen@10.2.1:
     resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -2634,6 +2693,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2690,12 +2752,18 @@ packages:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
 
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   steamworks.js@0.4.0:
     resolution: {integrity: sha512-O5TTRs7ucCRql4IA/kYUIQYeghTsXqf3rAm81sC22RDId264LQYqQjuaMEUSqL60I5LdULiGu0W2/A+ZDcKBKA==}
@@ -2762,9 +2830,20 @@ packages:
   through2@4.0.2:
     resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -2955,12 +3034,58 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wide-align@1.1.5:
@@ -3746,6 +3871,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -3785,6 +3912,11 @@ snapshots:
       '@types/node': 26.0.0
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/chroma-js@3.1.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -3796,6 +3928,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -4045,6 +4179,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@6.4.3(@types/node@26.0.0)(lightningcss@1.32.0)(terser@5.48.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.3(@types/node@26.0.0)(lightningcss@1.32.0)(terser@5.48.0)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xmldom/xmldom@0.9.10': {}
 
   abbrev@1.1.1: {}
@@ -4182,6 +4357,8 @@ snapshots:
 
   assert-plus@1.0.0:
     optional: true
+
+  assertion-error@2.0.1: {}
 
   astral-regex@2.0.0: {}
 
@@ -4329,6 +4506,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001799: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4768,12 +4947,18 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   eval@0.1.8:
     dependencies:
       '@types/node': 26.0.0
       require-like: 0.1.2
+
+  expect-type@1.4.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -5280,6 +5465,10 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   make-fetch-happen@10.2.1:
     dependencies:
       agentkeepalive: 4.6.0
@@ -5776,6 +5965,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -5832,9 +6023,13 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
 
   stats.js@0.17.0: {}
+
+  std-env@4.1.0: {}
 
   steamworks.js@0.4.0:
     dependencies:
@@ -5924,10 +6119,16 @@ snapshots:
     dependencies:
       readable-stream: 3.6.2
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -6061,6 +6262,33 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.48.0
 
+  vitest@4.1.9(@types/node@26.0.0)(vite@6.4.3(@types/node@26.0.0)(lightningcss@1.32.0)(terser@5.48.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@6.4.3(@types/node@26.0.0)(lightningcss@1.32.0)(terser@5.48.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 6.4.3(@types/node@26.0.0)(lightningcss@1.32.0)(terser@5.48.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.0.0
+    transitivePeerDependencies:
+      - msw
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -6068,6 +6296,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wide-align@1.1.5:
     dependencies:

--- a/src/classes/Scheduler.test.ts
+++ b/src/classes/Scheduler.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Scheduler } from "./Scheduler";
+
+/**
+ * Minimal fake of the WebAudio surface the Scheduler touches. The Scheduler
+ * fires callbacks via `BufferSourceNode.onended` on silent 1-sample buffers;
+ * here `advanceTo` plays the audio clock forward, firing `onended` (in end-time
+ * order, with `currentTime` set to each source's end time) for every started,
+ * un-stopped source whose playback has finished. Firing can schedule new
+ * sources (the repeating chain), so the scan repeats until nothing is due.
+ */
+class FakeBufferSource {
+  buffer: { duration: number } | null = null;
+  onended: (() => void) | null = null;
+  startTime: number | null = null;
+  stopped = false;
+  fired = false;
+
+  constructor(private ctx: FakeAudioContext) {}
+
+  connect(): void {}
+  disconnect(): void {}
+
+  start(when = 0): void {
+    // WebAudio clamps a start time in the past to "now"
+    this.startTime = Math.max(when, this.ctx.currentTime);
+  }
+
+  stop(): void {
+    if (this.startTime === null) throw new Error("InvalidStateError");
+    this.stopped = true;
+  }
+
+  get endTime(): number {
+    return this.startTime! + (this.buffer?.duration ?? 0);
+  }
+}
+
+class FakeAudioContext {
+  currentTime = 0;
+  destination = {};
+  sources: FakeBufferSource[] = [];
+
+  createBuffer(
+    _channels: number,
+    length: number,
+    sampleRate: number
+  ): { duration: number } {
+    return { duration: length / sampleRate };
+  }
+
+  createBufferSource(): FakeBufferSource {
+    const source = new FakeBufferSource(this);
+    this.sources.push(source);
+    return source;
+  }
+
+  advanceTo(time: number): void {
+    for (;;) {
+      const due = this.sources
+        .filter(
+          (s) => !s.fired && !s.stopped && s.startTime !== null && s.endTime <= time
+        )
+        .sort((a, b) => a.endTime - b.endTime)[0];
+      if (!due) break;
+      due.fired = true;
+      this.currentTime = due.endTime;
+      due.onended?.();
+    }
+    this.currentTime = time;
+  }
+}
+
+// 1-sample dummy buffer at 44.1kHz — the lead time the Scheduler subtracts
+const DUMMY_DURATION = 1 / 44100;
+
+describe("Scheduler", () => {
+  let ctx: FakeAudioContext;
+  let scheduler: Scheduler;
+
+  beforeEach(() => {
+    ctx = new FakeAudioContext();
+    scheduler = new Scheduler(ctx as unknown as AudioContext);
+  });
+
+  describe("scheduleOnce", () => {
+    it("fires the callback at the scheduled time, not early", () => {
+      const cb = vi.fn();
+      scheduler.scheduleOnce(2, cb);
+
+      ctx.advanceTo(1.99);
+      expect(cb).not.toHaveBeenCalled();
+
+      ctx.advanceTo(2);
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires with the audio clock at the scheduled time", () => {
+      let firedAt = -1;
+      scheduler.scheduleOnce(2, () => (firedAt = ctx.currentTime));
+      ctx.advanceTo(3);
+      expect(firedAt).toBeCloseTo(2, 6);
+    });
+
+    it("starts the dummy source one buffer-length before the target time", () => {
+      scheduler.scheduleOnce(2, () => {});
+      expect(ctx.sources[0].startTime).toBeCloseTo(2 - DUMMY_DURATION, 12);
+    });
+
+    it("returns incrementing event ids synchronously when given a callback", () => {
+      const a = scheduler.scheduleOnce(1, () => {});
+      const b = scheduler.scheduleOnce(2, () => {});
+      expect(a).toBe(1);
+      expect(b).toBe(2);
+    });
+
+    it("removes its event from the queue after firing (callback path self-cleans)", () => {
+      const id = scheduler.scheduleOnce(1, () => {}) as number;
+      expect(scheduler.getEvent(id)).not.toBe(false);
+      ctx.advanceTo(1.5);
+      expect(scheduler.getEvent(id)).toBe(false);
+      expect(scheduler.queue).toHaveLength(0);
+    });
+
+    it("without a callback, resolves a promise with the event id when the event fires", async () => {
+      const promise = scheduler.scheduleOnce(2);
+      expect(promise).toBeInstanceOf(Promise);
+      ctx.advanceTo(2.5);
+      await expect(promise).resolves.toBe(1);
+    });
+
+    it("without a callback, leaves the fired event in the queue (promise path never self-cleans)", async () => {
+      // Characterization, likely a leak: the callback path calls cancel() after
+      // firing but the promise path does not, so the event lingers until clear().
+      const promise = scheduler.scheduleOnce(2);
+      ctx.advanceTo(2.5);
+      await promise;
+      expect(scheduler.queue).toHaveLength(1);
+      expect(scheduler.getEvent(1)).not.toBe(false);
+    });
+  });
+
+  describe("scheduleRepeating", () => {
+    it("fires at the start time and every `frequency` seconds after", () => {
+      const times: number[] = [];
+      scheduler.scheduleRepeating(1, 0.5, () => times.push(ctx.currentTime));
+
+      ctx.advanceTo(2.9);
+      expect(times).toHaveLength(4);
+      expect(times[0]).toBeCloseTo(1, 6);
+      expect(times[1]).toBeCloseTo(1.5, 6);
+      expect(times[2]).toBeCloseTo(2, 6);
+      expect(times[3]).toBeCloseTo(2.5, 6);
+    });
+
+    it("does not fire before the start time", () => {
+      const cb = vi.fn();
+      scheduler.scheduleRepeating(1, 0.5, cb);
+      ctx.advanceTo(0.99);
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("schedules each occurrence at `time + count * frequency` so drift cannot accumulate", () => {
+      scheduler.scheduleRepeating(1, 0.25, () => {});
+      ctx.advanceTo(5);
+
+      // 17 occurrences fired (1.0 .. 5.0); the live source is occurrence 17
+      const event = scheduler.getEvent(1);
+      expect(event).not.toBe(false);
+      expect((event as { count: number }).count).toBe(17);
+      const liveSource = ctx.sources[ctx.sources.length - 1];
+      expect(liveSource.startTime).toBeCloseTo(1 + 17 * 0.25 - DUMMY_DURATION, 12);
+    });
+
+    it("keeps a single queue entry across many occurrences", () => {
+      scheduler.scheduleRepeating(1, 0.25, () => {});
+      ctx.advanceTo(5);
+      expect(scheduler.queue).toHaveLength(1);
+    });
+
+    it("clamps a start time in the past to zero rather than throwing", () => {
+      scheduler.scheduleRepeating(DUMMY_DURATION / 2, 1, () => {});
+      expect(ctx.sources[0].startTime).toBe(0);
+    });
+  });
+
+  describe("updateCallback", () => {
+    it("swaps the callback for all subsequent occurrences", () => {
+      const first = vi.fn();
+      const second = vi.fn();
+      const id = scheduler.scheduleRepeating(1, 1, first);
+
+      ctx.advanceTo(1.5);
+      expect(first).toHaveBeenCalledTimes(1);
+
+      scheduler.updateCallback(id, second);
+      ctx.advanceTo(3.5);
+      expect(first).toHaveBeenCalledTimes(1);
+      expect(second).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("cancel", () => {
+    it("cancelling between schedule and fire prevents the callback and empties the queue", () => {
+      const cb = vi.fn();
+      const id = scheduler.scheduleOnce(2, cb) as number;
+
+      scheduler.cancel(id);
+      ctx.advanceTo(3);
+
+      expect(cb).not.toHaveBeenCalled();
+      expect(scheduler.queue).toHaveLength(0);
+      expect(ctx.sources[0].stopped).toBe(true);
+      expect(ctx.sources[0].onended).toBeNull();
+    });
+
+    it("cancelling a repeating event mid-stream stops all further occurrences", () => {
+      const cb = vi.fn();
+      const id = scheduler.scheduleRepeating(1, 0.5, cb);
+
+      ctx.advanceTo(1.6);
+      expect(cb).toHaveBeenCalledTimes(2);
+
+      scheduler.cancel(id);
+      ctx.advanceTo(4);
+      expect(cb).toHaveBeenCalledTimes(2);
+      expect(scheduler.queue).toHaveLength(0);
+    });
+
+    it("is a no-op for an unknown id and for undefined", () => {
+      scheduler.scheduleOnce(1, () => {});
+      scheduler.cancel(999);
+      scheduler.cancel(undefined);
+      expect(scheduler.queue).toHaveLength(1);
+    });
+  });
+
+  describe("clear", () => {
+    it("silences and removes every pending event", () => {
+      const a = vi.fn();
+      const b = vi.fn();
+      scheduler.scheduleOnce(1, a);
+      scheduler.scheduleRepeating(1, 0.5, b);
+
+      scheduler.clear();
+      ctx.advanceTo(5);
+
+      expect(a).not.toHaveBeenCalled();
+      expect(b).not.toHaveBeenCalled();
+      expect(scheduler.queue).toHaveLength(0);
+    });
+  });
+
+  describe("getEvent", () => {
+    it("returns false (not undefined) when the event is not found", () => {
+      expect(scheduler.getEvent(42)).toBe(false);
+    });
+  });
+});

--- a/src/classes/TempoClock.test.ts
+++ b/src/classes/TempoClock.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { TempoClock } from "./TempoClock";
+
+// bpm 120 = 2 beats/sec at rate 1 — keeps the arithmetic legible
+const BPM = 120;
+
+describe("TempoClock", () => {
+  describe("beatsAt / timeAt", () => {
+    it("at rate 1 anchored at 0, maps time to beats with the base bpm", () => {
+      const clock = new TempoClock(BPM);
+      expect(clock.beatsAt(0)).toBe(0);
+      expect(clock.beatsAt(3)).toBe(6);
+      expect(clock.timeAt(6)).toBe(3);
+    });
+
+    it.each([1.0, 0.7, 0.5])(
+      "round-trips time -> beats -> time at rate %s",
+      (rate) => {
+        const clock = new TempoClock(BPM);
+        clock.setRate(rate, 0);
+        for (const t of [0.1, 1, 12.34, 100.5]) {
+          expect(clock.timeAt(clock.beatsAt(t))).toBeCloseTo(t, 10);
+          expect(clock.beatsAt(clock.timeAt(t))).toBeCloseTo(t, 10);
+        }
+      }
+    );
+
+    it("scales beat accumulation by the rate", () => {
+      const clock = new TempoClock(BPM);
+      clock.setRate(0.5, 0);
+      expect(clock.beatsAt(3)).toBe(3); // 2 beats/sec * 0.5
+    });
+  });
+
+  describe("setRate", () => {
+    it("preserves the beat count at the instant of the change", () => {
+      const clock = new TempoClock(BPM);
+      expect(clock.beatsAt(10)).toBe(20);
+      clock.setRate(0.5, 10);
+      expect(clock.beatsAt(10)).toBe(20);
+    });
+
+    it("accumulates beats at the new rate after the change", () => {
+      const clock = new TempoClock(BPM);
+      clock.setRate(0.5, 10);
+      expect(clock.beatsAt(11)).toBe(21); // 2 beats/sec * 0.5 for 1s
+    });
+
+    it("carries beat continuity across multiple rate changes", () => {
+      const clock = new TempoClock(BPM);
+      clock.setRate(0.7, 5); // 10 beats by t=5
+      clock.setRate(0.5, 10); // + 2*0.7*5 = 7 -> 17 beats by t=10
+      expect(clock.beatsAt(10)).toBeCloseTo(17, 10);
+      expect(clock.beatsAt(12)).toBeCloseTo(19, 10);
+      expect(clock.timeAt(19)).toBeCloseTo(12, 10);
+    });
+  });
+
+  describe("nextBoundary / nextBoundaryBeat", () => {
+    it("lands on exact grid multiples of the interval", () => {
+      const clock = new TempoClock(BPM);
+      // 4-beat interval at 2 beats/sec -> boundaries every 2s
+      expect(clock.nextBoundaryBeat(4, 3.1)).toBe(8);
+      expect(clock.nextBoundary(4, 3.1)).toBe(4);
+      expect(clock.nextBoundary(4, 0.01)).toBe(2);
+    });
+
+    it("returns the boundary strictly after `fromTime` when already exactly on one", () => {
+      const clock = new TempoClock(BPM);
+      expect(clock.beatsAt(2)).toBe(4); // exactly on the 4-beat grid
+      expect(clock.nextBoundaryBeat(4, 2)).toBe(8);
+      expect(clock.nextBoundary(4, 2)).toBe(4);
+    });
+
+    it("spaces boundaries by interval / (bps * rate) under a slowed rate", () => {
+      const clock = new TempoClock(BPM);
+      clock.setRate(0.5, 0);
+      // 4 beats at 1 effective beat/sec -> boundaries every 4s
+      expect(clock.nextBoundary(4, 0.1)).toBe(4);
+      expect(clock.nextBoundary(4, 4.1)).toBe(8);
+    });
+
+    it("keeps the boundary's beat identity fixed across a rate change while its wall-clock time moves", () => {
+      // This is what lets a pending voice re-resolve its start against the live
+      // grid: the target beat is rate-invariant, timeAt() gives the live time.
+      const clock = new TempoClock(BPM);
+      const targetBeat = clock.nextBoundaryBeat(4, 9); // beats 18 -> beat 20
+      expect(targetBeat).toBe(20);
+      expect(clock.timeAt(targetBeat)).toBe(10);
+
+      clock.setRate(0.5, 9.5); // 19 beats elapsed; 1 beat left at 1 beat/sec
+      expect(clock.nextBoundaryBeat(4, 9.5)).toBe(targetBeat);
+      expect(clock.timeAt(targetBeat)).toBeCloseTo(10.5, 10);
+    });
+  });
+
+  describe("currentRate / effectiveBpm", () => {
+    it("reports the last commanded rate", () => {
+      // AudioPlayerWrapper.start reads this at commit time so a voice comes in
+      // at the live rate rather than one pinned at schedule time.
+      const clock = new TempoClock(BPM);
+      expect(clock.currentRate).toBe(1);
+      clock.setRate(0.7, 3);
+      expect(clock.currentRate).toBe(0.7);
+      clock.setRate(0.5, 6);
+      expect(clock.currentRate).toBe(0.5);
+    });
+
+    it("reports the effective bpm as base bpm scaled by the rate", () => {
+      const clock = new TempoClock(BPM);
+      expect(clock.effectiveBpm).toBe(120);
+      clock.setRate(0.7, 0);
+      expect(clock.effectiveBpm).toBeCloseTo(84, 10);
+    });
+  });
+});

--- a/src/components/EffectsPanel.tsx
+++ b/src/components/EffectsPanel.tsx
@@ -1,5 +1,6 @@
 import { useContext, useRef, useState, useEffect } from "react";
-import { clamp, lerp } from "../utils/mathUtils";
+import { lerp } from "../utils/mathUtils";
+import { chooseNewValue } from "./effectWalk";
 
 import { WebAudioContext } from "../contexts/contexts";
 import { SongContext } from "../contexts/contexts";
@@ -39,26 +40,6 @@ const LP_WALK_FLOOR = 55;
 // target.
 const GLIDE_STEPS = 20;
 const GLIDE_STEP_S = 0.03;
-
-// The edge-avoidance margin (bounds) and step size (effectSize) were tuned on
-// the full 1-100 range as 35 and 40; they scale with the actual range so a
-// narrowed safe zone (e.g. the background-mode lp walk, 55-100) wanders the same
-// way. With the fixed values, the middle "gentle wander" branch is unreachable
-// in a narrow range and the walk just ratchets between the bounds.
-const chooseNewValue = (prev: number, min = 1, max = 100): number => {
-  const range = max - min;
-  const bounds = (35 / 99) * range;
-  const effectSize = (40 / 99) * range;
-  let newValue: number;
-  if (prev < min + bounds) {
-    newValue = prev + Math.random() * effectSize;
-  } else if (prev > max - bounds) {
-    newValue = prev - Math.random() * effectSize;
-  } else {
-    newValue = prev + (-0.5 + Math.random()) * effectSize;
-  }
-  return clamp(newValue, min, max);
-};
 
 interface Preset {
   timeWarp: number;

--- a/src/components/effectWalk.test.ts
+++ b/src/components/effectWalk.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { chooseNewValue } from "./effectWalk";
+
+// The background-mode safe zones from EffectsPanel: hp walks 1..HP_WALK_CEIL,
+// lp walks LP_WALK_FLOOR..100.
+const HP_WALK_CEIL = 72;
+const LP_WALK_FLOOR = 55;
+
+/** Pin Math.random to a repeating sequence for deterministic walks. */
+const seedRandom = (sequence: number[]) => {
+  let i = 0;
+  vi.spyOn(Math, "random").mockImplementation(
+    () => sequence[i++ % sequence.length]
+  );
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("chooseNewValue", () => {
+  describe("full 1-100 range (original tuned constants: bounds 35, step 40)", () => {
+    it("walks upward from the low band (prev < 36)", () => {
+      seedRandom([0.5]);
+      expect(chooseNewValue(10)).toBeCloseTo(10 + 0.5 * 40, 10);
+    });
+
+    it("walks downward from the high band (prev > 65)", () => {
+      seedRandom([0.5]);
+      expect(chooseNewValue(90)).toBeCloseTo(90 - 0.5 * 40, 10);
+    });
+
+    it("wanders gently in the middle band, centered on zero movement", () => {
+      seedRandom([0.5]);
+      expect(chooseNewValue(50)).toBeCloseTo(50, 10);
+      seedRandom([0.75]);
+      expect(chooseNewValue(50)).toBeCloseTo(60, 10);
+      seedRandom([0.25]);
+      expect(chooseNewValue(50)).toBeCloseTo(40, 10);
+    });
+
+    it("switches branches exactly at min+35 and max-35", () => {
+      // at r=0.5 the low branch moves +20 while the middle branch holds still
+      seedRandom([0.5]);
+      expect(chooseNewValue(35.9)).toBeCloseTo(55.9, 10); // low branch
+      seedRandom([0.5]);
+      expect(chooseNewValue(36)).toBeCloseTo(36, 10); // middle branch
+      seedRandom([0.5]);
+      expect(chooseNewValue(65)).toBeCloseTo(65, 10); // middle branch
+      seedRandom([0.5]);
+      expect(chooseNewValue(65.1)).toBeCloseTo(45.1, 10); // high branch
+    });
+
+    it("clamps the result into the range", () => {
+      seedRandom([0]);
+      expect(chooseNewValue(110)).toBe(100);
+      expect(chooseNewValue(-10)).toBe(1);
+    });
+  });
+
+  describe("narrowed safe-zone ranges (margins scale as fractions of the range)", () => {
+    it("scales the step to the range: low-branch move in 55-100 is (40/99)*45", () => {
+      seedRandom([0.5]);
+      expect(chooseNewValue(60, LP_WALK_FLOOR, 100)).toBeCloseTo(
+        60 + ((40 / 99) * 45) / 2,
+        10
+      );
+    });
+
+    it("keeps the gentle middle branch reachable in a narrow range", () => {
+      // With the old fixed bounds (35), min+35=90 > max-35=65 and the middle
+      // branch was unreachable in 55-100 — the walk just ratcheted between the
+      // edges. Scaled bounds put the middle band at ~70.9..84.1.
+      seedRandom([0.5]);
+      expect(chooseNewValue(77, LP_WALK_FLOOR, 100)).toBeCloseTo(77, 10); // zero step = middle branch
+    });
+
+    const wanderSequence = [
+      0.13, 0.87, 0.42, 0.61, 0.29, 0.74, 0.05, 0.96, 0.5, 0.33, 0.68, 0.21,
+      0.79, 0.47, 0.58, 0.09, 0.91, 0.36, 0.64, 0.25,
+    ];
+
+    it.each([
+      ["hp", 1, HP_WALK_CEIL, 36],
+      ["lp", LP_WALK_FLOOR, 100, 78],
+    ])(
+      "the %s walk stays interior and varies instead of ratcheting to a bound",
+      (_label, min, max, start) => {
+        seedRandom(wanderSequence);
+        const values: number[] = [];
+        let value = start;
+        for (let step = 0; step < 20; step++) {
+          value = chooseNewValue(value, min, max);
+          values.push(value);
+        }
+        // never escapes or pins to the range edges
+        for (const v of values) {
+          expect(v).toBeGreaterThan(min);
+          expect(v).toBeLessThan(max);
+        }
+        // moves in both directions and keeps finding new values
+        const deltas = values.map((v, idx) => v - (idx === 0 ? start : values[idx - 1]));
+        expect(deltas.some((d) => d > 0)).toBe(true);
+        expect(deltas.some((d) => d < 0)).toBe(true);
+        expect(new Set(values.map((v) => v.toFixed(3))).size).toBeGreaterThan(10);
+      }
+    );
+  });
+});

--- a/src/components/effectWalk.ts
+++ b/src/components/effectWalk.ts
@@ -1,0 +1,25 @@
+import { clamp } from "../utils/mathUtils";
+
+// The edge-avoidance margin (bounds) and step size (effectSize) were tuned on
+// the full 1-100 range as 35 and 40; they scale with the actual range so a
+// narrowed safe zone (e.g. the background-mode lp walk, 55-100) wanders the same
+// way. With the fixed values, the middle "gentle wander" branch is unreachable
+// in a narrow range and the walk just ratchets between the bounds.
+//
+// Lives in its own module (rather than EffectsPanel.tsx) so the walk math can be
+// unit-tested without dragging the component's vanilla-extract styles into a
+// node test environment.
+export const chooseNewValue = (prev: number, min = 1, max = 100): number => {
+  const range = max - min;
+  const bounds = (35 / 99) * range;
+  const effectSize = (40 / 99) * range;
+  let newValue: number;
+  if (prev < min + bounds) {
+    newValue = prev + Math.random() * effectSize;
+  } else if (prev > max - bounds) {
+    newValue = prev - Math.random() * effectSize;
+  } else {
+    newValue = prev + (-0.5 + Math.random()) * effectSize;
+  }
+  return clamp(newValue, min, max);
+};

--- a/src/stores/musicPlayerStore.test.ts
+++ b/src/stores/musicPlayerStore.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useMusicPlayerStore, VoiceState } from "./musicPlayerStore";
+
+// The store is headless-testable: actions and state via getState(), no React.
+const store = () => useMusicPlayerStore.getState();
+
+/** Voice.ref is only ever `.click()`ed by background mode — a stub suffices. */
+const makeVoice = (id: string, group: string, voiceState: VoiceState = "stopped") => ({
+  id,
+  group,
+  voiceState,
+  ref: {} as HTMLElement,
+});
+
+/**
+ * Register `group`, then bring `ids` in one at a time the way ToggleButton
+ * does: add the voice as pending-start, queue it, then mark it active.
+ */
+const bringIn = (group: string, maxPolyphony: number, ids: string[]) => {
+  store().registerGroup(group, maxPolyphony);
+  for (const id of ids) {
+    store().addVoice(makeVoice(id, group, "pending-start"));
+    store().queueVoice(group, id, "pending-start");
+    store().updateVoiceState({ id, newState: "active" });
+  }
+};
+
+describe("useMusicPlayerStore", () => {
+  beforeEach(() => {
+    store().reset();
+  });
+
+  describe("initial state", () => {
+    it("starts with the documented defaults, including timeWarp 0 and energy 0.5", () => {
+      const s = store();
+      expect(s.voices).toEqual([]);
+      expect(s.groups).toEqual({});
+      expect(s.groupSolos).toEqual([]);
+      expect(s.backgroundMode).toBe(false);
+      expect(s.timeWarp).toBe(0);
+      expect(s.energy).toBe(0.5);
+      expect(s.pauseVisuals).toBe(false);
+      expect(s.mute).toBe(false);
+    });
+  });
+
+  describe("voice state transitions", () => {
+    it("addVoice appends voices in call order", () => {
+      store().addVoice(makeVoice("a", "g"));
+      store().addVoice(makeVoice("b", "g"));
+      expect(store().voices.map((v) => v.id)).toEqual(["a", "b"]);
+    });
+
+    it("updateVoiceState walks a voice through the full lifecycle", () => {
+      store().addVoice(makeVoice("a", "g"));
+      for (const state of ["pending-start", "active", "pending-stop", "stopped"] as const) {
+        store().updateVoiceState({ id: "a", newState: state });
+        expect(store().voices[0].voiceState).toBe(state);
+      }
+    });
+
+    it("updating a voice does NOT move it to the end of the array", () => {
+      // Order preservation matters: the viz reads `voices` positionally each frame.
+      store().addVoice(makeVoice("a", "g"));
+      store().addVoice(makeVoice("b", "g"));
+      store().addVoice(makeVoice("c", "g"));
+      store().updateVoiceState({ id: "b", newState: "active" });
+      expect(store().voices.map((v) => v.id)).toEqual(["a", "b", "c"]);
+      expect(store().voices[1].voiceState).toBe("active");
+    });
+
+    it("updateVoiceState with an unknown id changes nothing", () => {
+      store().addVoice(makeVoice("a", "g", "active"));
+      store().updateVoiceState({ id: "nope", newState: "stopped" });
+      expect(store().voices).toEqual([makeVoice("a", "g", "active")]);
+    });
+  });
+
+  describe("polyphony and eviction", () => {
+    it("registerGroup starts a group with an empty order and no overrides", () => {
+      store().registerGroup("g", 2);
+      expect(store().groups.g).toEqual({
+        maxPolyphony: 2,
+        playerOrder: [],
+        playerOverrides: [],
+      });
+    });
+
+    it("appends voices in arrival order while under the cap", () => {
+      bringIn("g", 3, ["a", "b", "c"]);
+      expect(store().groups.g.playerOrder).toEqual(["a", "b", "c"]);
+      expect(store().groups.g.playerOverrides).toEqual([]);
+    });
+
+    it("unlimited groups (maxPolyphony -1) never evict", () => {
+      bringIn("g", -1, ["a", "b", "c", "d", "e"]);
+      expect(store().groups.g.playerOrder).toEqual(["a", "b", "c", "d", "e"]);
+      expect(store().groups.g.playerOverrides).toEqual([]);
+    });
+
+    it("in a poly=1 group, a second voice overrides the first", () => {
+      bringIn("g", 1, ["a", "b"]);
+      expect(store().groups.g.playerOrder).toEqual(["b"]);
+      expect(store().groups.g.playerOverrides).toEqual(["a"]);
+    });
+
+    it("in a poly=N group, the oldest voice is evicted first", () => {
+      bringIn("g", 2, ["a", "b", "c"]);
+      expect(store().groups.g.playerOrder).toEqual(["b", "c"]);
+      expect(store().groups.g.playerOverrides).toEqual(["a"]);
+    });
+
+    it("a later eviction replaces the override list rather than accumulating", () => {
+      bringIn("g", 1, ["a", "b", "c"]);
+      // b's override of a is discarded when c overrides b
+      expect(store().groups.g.playerOrder).toEqual(["c"]);
+      expect(store().groups.g.playerOverrides).toEqual(["b"]);
+    });
+
+    it("clearVoiceOverride removes the voice from the override list", () => {
+      bringIn("g", 1, ["a", "b"]);
+      store().clearVoiceOverride("g", "a");
+      expect(store().groups.g.playerOverrides).toEqual([]);
+    });
+
+    it("queueVoice pending-stop removes the voice from the order without touching overrides", () => {
+      bringIn("g", 2, ["a", "b"]);
+      store().updateVoiceState({ id: "a", newState: "pending-stop" });
+      store().queueVoice("g", "a", "pending-stop");
+      expect(store().groups.g.playerOrder).toEqual(["b"]);
+      expect(store().groups.g.playerOverrides).toEqual([]);
+    });
+
+    it("queueVoice on an unregistered group is a no-op", () => {
+      store().queueVoice("ghost", "a", "pending-start");
+      expect(store().groups).toEqual({});
+    });
+  });
+
+  describe("solo and mute", () => {
+    it("addGroupSolo replaces any existing solo (single-solo semantics)", () => {
+      store().addGroupSolo("drums");
+      store().addGroupSolo("keys");
+      expect(store().groupSolos).toEqual(["keys"]);
+    });
+
+    it("removeGroupSolo clears the solo list", () => {
+      store().addGroupSolo("drums");
+      store().removeGroupSolo();
+      expect(store().groupSolos).toEqual([]);
+    });
+
+    it("startMute and stopMute toggle the mute flag", () => {
+      store().startMute();
+      expect(store().mute).toBe(true);
+      store().stopMute();
+      expect(store().mute).toBe(false);
+    });
+  });
+
+  describe("reset and randomize callback registries", () => {
+    it("registers callbacks by name and invokes them", () => {
+      const onReset = vi.fn();
+      const onRandomize = vi.fn();
+      store().addResetCallback({ name: "hats", callback: onReset });
+      store().addRandomizeCallback({ name: "hats", callback: onRandomize });
+
+      store().resetCallbacks.forEach((cb) => cb.callback());
+      store().randomizeCallbacks.forEach((cb) => cb.callback());
+      expect(onReset).toHaveBeenCalledTimes(1);
+      expect(onRandomize).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-registering the same name replaces the callback and moves it to the end", () => {
+      const stale = vi.fn();
+      const fresh = vi.fn();
+      store().addResetCallback({ name: "hats", callback: stale });
+      store().addResetCallback({ name: "keys", callback: vi.fn() });
+      store().addResetCallback({ name: "hats", callback: fresh });
+
+      expect(store().resetCallbacks.map((cb) => cb.name)).toEqual(["keys", "hats"]);
+      store().resetCallbacks.forEach((cb) => cb.callback());
+      expect(stale).not.toHaveBeenCalled();
+      expect(fresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("background mode, time warp, and energy", () => {
+    it("setBackgroundMode, setTimeWarp, setEnergy, and setPauseVisuals write their slices", () => {
+      store().setBackgroundMode(true);
+      store().setTimeWarp(0.4);
+      store().setEnergy(0.08);
+      store().setPauseVisuals(true);
+      const s = store();
+      expect(s.backgroundMode).toBe(true);
+      expect(s.timeWarp).toBe(0.4);
+      expect(s.energy).toBe(0.08);
+      expect(s.pauseVisuals).toBe(true);
+    });
+  });
+
+  describe("reset", () => {
+    it("returns every data slice to its initial value", () => {
+      bringIn("g", 1, ["a", "b"]);
+      store().addGroupSolo("g");
+      store().addResetCallback({ name: "x", callback: vi.fn() });
+      store().setBackgroundMode(true);
+      store().setTimeWarp(0.9);
+      store().setEnergy(0.9);
+      store().startMute();
+
+      store().reset();
+
+      const s = store();
+      expect(s.voices).toEqual([]);
+      expect(s.groups).toEqual({});
+      expect(s.groupSolos).toEqual([]);
+      expect(s.resetCallbacks).toEqual([]);
+      expect(s.randomizeCallbacks).toEqual([]);
+      expect(s.backgroundMode).toBe(false);
+      expect(s.timeWarp).toBe(0);
+      expect(s.energy).toBe(0.5);
+      expect(s.mute).toBe(false);
+    });
+  });
+});

--- a/src/utils/audioUtils.test.ts
+++ b/src/utils/audioUtils.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { nextSubdivision, loadArrayBuffer, averageVolume } from "./audioUtils";
+
+/** nextSubdivision only reads `currentTime` off the context. */
+const ctxAt = (currentTime: number) =>
+  ({ currentTime } as unknown as AudioContext);
+
+describe("nextSubdivision", () => {
+  it("returns the first boundary after time zero", () => {
+    // 60bpm, 1-beat subdivision -> boundaries every 1s
+    expect(nextSubdivision(ctxAt(0), 60, 1)).toBe(1);
+  });
+
+  it("returns the boundary strictly after the current time when already exactly on one", () => {
+    expect(nextSubdivision(ctxAt(2), 60, 1)).toBe(3);
+  });
+
+  it.each([
+    // [currentTime, bpm, beats, expected]: expected = (floor(elapsed/subdiv)+1) * subdiv
+    [3.1, 120, 4, 4], // 2s subdivisions
+    [1.5, 90, 2, 8 / 3], // 4/3s subdivisions
+    [10.2, 60, 3, 12],
+    [0.4, 140, 1, 60 / 140],
+  ])(
+    "at t=%s with bpm=%s beats=%s returns %s",
+    (currentTime, bpm, beats, expected) => {
+      expect(nextSubdivision(ctxAt(currentTime), bpm, beats)).toBeCloseTo(
+        expected,
+        10
+      );
+    }
+  );
+
+  it("always lands on an exact multiple of the subdivision length", () => {
+    const bpm = 87;
+    const beats = 4;
+    const subdivision = beats * (60 / bpm);
+    const result = nextSubdivision(ctxAt(17.3), bpm, beats);
+    expect(result / subdivision).toBeCloseTo(Math.round(result / subdivision), 10);
+    expect(result).toBeGreaterThan(17.3);
+  });
+});
+
+describe("averageVolume", () => {
+  it("averages the fft bins and normalizes by 255", () => {
+    expect(averageVolume(new Uint8Array([255, 255]))).toBe(1);
+    expect(averageVolume(new Uint8Array([0, 255]))).toBe(0.5);
+    expect(averageVolume(new Uint8Array([0, 0, 0]))).toBe(0);
+  });
+});
+
+describe("loadArrayBuffer", () => {
+  /** Just enough XHR to drive the load/error listeners by hand. */
+  class FakeXHR {
+    static latest: FakeXHR;
+    responseType = "";
+    status = 0;
+    response: unknown = null;
+    listeners: Record<string, Array<(arg?: unknown) => void>> = {};
+    opened?: { method: string; url: string };
+
+    constructor() {
+      FakeXHR.latest = this;
+    }
+
+    addEventListener(type: string, fn: (arg?: unknown) => void): void {
+      (this.listeners[type] ??= []).push(fn);
+    }
+
+    open(method: string, url: string): void {
+      this.opened = { method, url };
+    }
+
+    send(): void {}
+
+    emit(type: string, arg?: unknown): void {
+      this.listeners[type]?.forEach((fn) => fn(arg));
+    }
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("XMLHttpRequest", FakeXHR);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves with the response body on HTTP 200", async () => {
+    const promise = loadArrayBuffer("audio/test.mp3");
+    const xhr = FakeXHR.latest;
+    expect(xhr.opened).toEqual({ method: "GET", url: "audio/test.mp3" });
+
+    const body = new ArrayBuffer(8);
+    xhr.status = 200;
+    xhr.response = body;
+    xhr.emit("load");
+
+    await expect(promise).resolves.toBe(body);
+  });
+
+  it("rejects on a non-200 'load' (404) instead of hanging forever", async () => {
+    const promise = loadArrayBuffer("audio/missing.mp3");
+    const xhr = FakeXHR.latest;
+    xhr.status = 404;
+    xhr.emit("load");
+
+    await expect(promise).rejects.toThrow(
+      "Failed to load audio (HTTP 404): audio/missing.mp3"
+    );
+  });
+
+  it("rejects when the network errors out", async () => {
+    const promise = loadArrayBuffer("audio/test.mp3");
+    const failure = new Error("network down");
+    FakeXHR.latest.emit("error", failure);
+
+    await expect(promise).rejects.toBe(failure);
+  });
+});

--- a/src/utils/mathUtils.test.ts
+++ b/src/utils/mathUtils.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  clamp,
+  normalize,
+  lerp,
+  solveExpEquation,
+  linToLog,
+  boundedSin,
+  gaussianRand,
+  rotatePoint,
+} from "./mathUtils";
+
+describe("clamp", () => {
+  it("passes through values inside the range and pins values outside it", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+    expect(clamp(-3, 0, 10)).toBe(0);
+    expect(clamp(42, 0, 10)).toBe(10);
+    expect(clamp(0, 0, 10)).toBe(0);
+    expect(clamp(10, 0, 10)).toBe(10);
+  });
+});
+
+describe("normalize", () => {
+  it("maps min->0, max->1, and interpolates linearly between", () => {
+    expect(normalize(0, 0, 10)).toBe(0);
+    expect(normalize(10, 0, 10)).toBe(1);
+    expect(normalize(5, 0, 10)).toBe(0.5);
+    expect(normalize(25, 20, 40)).toBe(0.25);
+  });
+
+  it("without doClamp, values outside the range extrapolate past 0..1", () => {
+    expect(normalize(15, 0, 10)).toBe(1.5);
+    expect(normalize(-2, 0, 10)).toBe(-0.2);
+  });
+
+  it("with doClamp, clamps the normalized result to 0..1 (not to min..max)", () => {
+    // Deliberate divergence from the old crco-utils normalize, which clamped
+    // incorrectly — the clamp applies to the 0..1 output.
+    expect(normalize(15, 0, 10, true)).toBe(1);
+    expect(normalize(-2, 0, 10, true)).toBe(0);
+    expect(normalize(5, 0, 10, true)).toBe(0.5);
+  });
+});
+
+describe("lerp", () => {
+  it("returns the endpoints at t=0 and t=1 and the midpoint at t=0.5", () => {
+    expect(lerp(2, 10, 0)).toBe(2);
+    expect(lerp(2, 10, 1)).toBe(10);
+    expect(lerp(2, 10, 0.5)).toBe(6);
+  });
+
+  it("extrapolates beyond the endpoints for t outside 0..1", () => {
+    expect(lerp(0, 10, 1.5)).toBe(15);
+    expect(lerp(0, 10, -0.5)).toBe(-5);
+  });
+});
+
+describe("solveExpEquation", () => {
+  it("returns a, b such that y = a*b^x passes through both input points", () => {
+    // The lpFilter mapping from audioUtils.effectParams
+    const { a, b } = solveExpEquation(1, 320, 100, 20000);
+    expect(a * Math.pow(b, 1)).toBeCloseTo(320, 8);
+    expect(a * Math.pow(b, 100)).toBeCloseTo(20000, 8);
+  });
+});
+
+describe("linToLog", () => {
+  it("returns a, b such that y = a*e^(bx) fixes the endpoints (1,1) and (w,w)", () => {
+    const w = 10;
+    const { a, b } = linToLog(w);
+    expect(a * Math.exp(b * 1)).toBeCloseTo(1, 10);
+    expect(a * Math.exp(b * w)).toBeCloseTo(w, 10);
+  });
+});
+
+describe("boundedSin", () => {
+  it("oscillates between yMin and yMax starting at the midpoint", () => {
+    const f = boundedSin(2, 0, 1);
+    expect(f(0)).toBeCloseTo(0.5, 10);
+    expect(f(0.5)).toBeCloseTo(1, 10); // crest
+    expect(f(1.5)).toBeCloseTo(0, 10); // trough
+    expect(f(2)).toBeCloseTo(0.5, 10); // full period
+  });
+
+  it("invert flips the waveform", () => {
+    const f = boundedSin(2, 0, 1, 0, 0, true);
+    expect(f(0.5)).toBeCloseTo(0, 10);
+    expect(f(1.5)).toBeCloseTo(1, 10);
+  });
+});
+
+describe("gaussianRand", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("averages `factor` uniform samples", () => {
+    const spy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    expect(gaussianRand()).toBe(0.5);
+    expect(spy).toHaveBeenCalledTimes(6); // default factor
+    expect(gaussianRand(3)).toBe(0.5);
+    expect(spy).toHaveBeenCalledTimes(9);
+  });
+});
+
+describe("rotatePoint", () => {
+  it("rotates a point about a center by the given angle", () => {
+    const quarter = rotatePoint(1, 0, 0, 0, Math.PI / 2);
+    expect(quarter.x).toBeCloseTo(0, 10);
+    expect(quarter.y).toBeCloseTo(1, 10);
+
+    const offCenter = rotatePoint(3, 2, 2, 2, Math.PI);
+    expect(offCenter.x).toBeCloseTo(1, 10);
+    expect(offCenter.y).toBeCloseTo(2, 10);
+  });
+});

--- a/src/viz/SceneManager.ts
+++ b/src/viz/SceneManager.ts
@@ -2,17 +2,7 @@ import * as THREE from "three";
 import { GLTFLoader, GLTF } from "three/examples/jsm/loaders/GLTFLoader";
 import FirstPersonControls from "./controls/FirstPersonControls";
 import { FrameTelemetry, TelemetrySnapshot } from "./telemetry";
-
-// Cap the render loop to 60fps. On high-refresh displays (120Hz+) RAF would
-// otherwise render 2x as often — pure heat/battery for an ambient visualizer,
-// with no visible benefit (motion is time-based, not per-frame).
-const TARGET_FPS = 60;
-const FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
-// Jitter margin: render when within this of the target interval. Without it, a
-// true 60Hz display (frames arriving a hair under 16.67ms) gets halved to 30fps;
-// the margin sits safely between a 120Hz frame (8.33ms) and a 60Hz one (16.67ms),
-// so 60Hz renders every frame and 120Hz renders every other = 60.
-const FRAME_TOLERANCE_MS = 4;
+import { frameGate } from "./frameGate";
 
 // stats.js has no bundled types — minimal shim for the dynamic import
 interface StatsPanel {
@@ -266,17 +256,10 @@ export class SceneManager {
     if (this.disposed) return;
     this.currentFrame = requestAnimationFrame(this.animate);
 
-    // Frame-rate cap: skip this tick unless ~1/60s (minus a jitter margin) has
-    // elapsed since the last rendered frame. Advance the accumulator by the
-    // exact interval rather than snapping to `now`, so the remainder carries
-    // over — snapping quantizes the rate to refresh/ceil(interval/period),
-    // e.g. 90Hz→45fps, 144Hz→72fps, 165Hz→55fps.
-    const now = performance.now();
-    if (now - this.lastFrameTime < FRAME_INTERVAL_MS - FRAME_TOLERANCE_MS) return;
-    this.lastFrameTime += FRAME_INTERVAL_MS;
-    // Drift clamp: after a stall (hidden tab, long GC pause) the accumulator
-    // sits far in the past and would render every tick to "catch up" — resync.
-    if (now - this.lastFrameTime > 2 * FRAME_INTERVAL_MS) this.lastFrameTime = now;
+    // Frame-rate cap (60fps, remainder-carrying, drift-clamped) — see frameGate.
+    const gate = frameGate(performance.now(), this.lastFrameTime);
+    this.lastFrameTime = gate.lastFrameTime;
+    if (!gate.render) return;
 
     this.showStats && this.helpers.stats?.begin();
     this.telemetry?.beginFrame();

--- a/src/viz/frameGate.test.ts
+++ b/src/viz/frameGate.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { frameGate, FRAME_INTERVAL_MS, FRAME_TOLERANCE_MS } from "./frameGate";
+
+/**
+ * Feed the gate a train of RAF ticks arriving at `hz` and count the renders,
+ * exactly as SceneManager.animate consumes it: carry the returned accumulator
+ * into the next tick.
+ */
+const runTrain = (hz: number, seconds: number) => {
+  const periodMs = 1000 / hz;
+  const ticks = Math.floor(seconds * hz);
+  let lastFrameTime = 0;
+  let renders = 0;
+  for (let i = 1; i <= ticks; i++) {
+    const gate = frameGate(i * periodMs, lastFrameTime);
+    lastFrameTime = gate.lastFrameTime;
+    if (gate.render) renders++;
+  }
+  return { renders, fps: renders / seconds, ticks };
+};
+
+describe("frameGate", () => {
+  it("skips a tick that arrives before the interval minus the jitter margin", () => {
+    const early = FRAME_INTERVAL_MS - FRAME_TOLERANCE_MS - 0.01;
+    expect(frameGate(early, 0)).toEqual({ render: false, lastFrameTime: 0 });
+  });
+
+  it("renders a tick that arrives within the jitter margin of the interval", () => {
+    const withinMargin = FRAME_INTERVAL_MS - FRAME_TOLERANCE_MS;
+    const gate = frameGate(withinMargin, 0);
+    expect(gate.render).toBe(true);
+    // the accumulator advances by the exact interval, not to `now`
+    expect(gate.lastFrameTime).toBe(FRAME_INTERVAL_MS);
+  });
+
+  it("renders every tick on a true 60Hz display", () => {
+    const { renders, ticks } = runTrain(60, 60);
+    expect(renders).toBe(ticks);
+  });
+
+  it("renders every other tick on a 120Hz display", () => {
+    const { renders, ticks } = runTrain(120, 60);
+    expect(renders).toBe(ticks / 2);
+  });
+
+  it.each([60, 90, 120, 144, 165])(
+    "averages ~60fps on a %sHz display (remainder carry-over, no quantization)",
+    (hz) => {
+      const { fps } = runTrain(hz, 60);
+      expect(fps).toBeGreaterThan(59);
+      expect(fps).toBeLessThan(61);
+    }
+  );
+
+  it("resyncs the accumulator after a long stall instead of rendering every tick to catch up", () => {
+    // steady state, then a 5s stall (hidden tab / GC pause)
+    let lastFrameTime = 0;
+    for (let i = 1; i <= 60; i++) {
+      lastFrameTime = frameGate(i * FRAME_INTERVAL_MS, lastFrameTime).lastFrameTime;
+    }
+    const stallEnd = 60 * FRAME_INTERVAL_MS + 5000;
+    const gate = frameGate(stallEnd, lastFrameTime);
+    expect(gate.render).toBe(true);
+    expect(gate.lastFrameTime).toBe(stallEnd);
+
+    // the very next 60Hz tick behaves normally again: one render per interval
+    const next = frameGate(stallEnd + FRAME_INTERVAL_MS, gate.lastFrameTime);
+    expect(next.render).toBe(true);
+    expect(next.lastFrameTime).toBe(stallEnd + FRAME_INTERVAL_MS);
+  });
+});

--- a/src/viz/frameGate.ts
+++ b/src/viz/frameGate.ts
@@ -1,0 +1,36 @@
+// Cap the render loop to 60fps. On high-refresh displays (120Hz+) RAF would
+// otherwise render 2x as often — pure heat/battery for an ambient visualizer,
+// with no visible benefit (motion is time-based, not per-frame).
+const TARGET_FPS = 60;
+export const FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
+// Jitter margin: render when within this of the target interval. Without it, a
+// true 60Hz display (frames arriving a hair under 16.67ms) gets halved to 30fps;
+// the margin sits safely between a 120Hz frame (8.33ms) and a 60Hz one (16.67ms),
+// so 60Hz renders every frame and 120Hz renders every other = 60.
+export const FRAME_TOLERANCE_MS = 4;
+
+/**
+ * Frame-rate cap decision for `SceneManager.animate`, kept free of three.js so
+ * it can be unit-tested: given the current RAF timestamp and the accumulator of
+ * the last rendered frame, decide whether to render this tick and return the
+ * advanced accumulator.
+ *
+ * Skips the tick unless ~1/60s (minus the jitter margin) has elapsed since the
+ * last rendered frame. On a render, the accumulator advances by the exact
+ * interval rather than snapping to `now`, so the remainder carries over —
+ * snapping quantizes the rate to refresh/ceil(interval/period), e.g. 90Hz→45fps,
+ * 144Hz→72fps, 165Hz→55fps. Drift clamp: after a stall (hidden tab, long GC
+ * pause) the accumulator sits far in the past and would render every tick to
+ * "catch up" — resync it to `now`.
+ */
+export const frameGate = (
+  now: number,
+  lastFrameTime: number
+): { render: boolean; lastFrameTime: number } => {
+  if (now - lastFrameTime < FRAME_INTERVAL_MS - FRAME_TOLERANCE_MS) {
+    return { render: false, lastFrameTime };
+  }
+  let next = lastFrameTime + FRAME_INTERVAL_MS;
+  if (now - next > 2 * FRAME_INTERVAL_MS) next = now;
+  return { render: true, lastFrameTime: next };
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Pins the framework-free core logic — the audio engine and store hardened over the last three review rounds — with 95 characterization tests so future refactors can't silently break it. Vitest 4.1.9 (exact pin), matching the version and config shape already on `blender-three-workflow` (the `vitest.config.ts` is byte-identical to that branch's, so the eventual merge is clean). Script is `test:unit`; CI runs it between typecheck and build.

## What's pinned per module

- **`src/classes/Scheduler.ts`** — one-shot events fire at the scheduled audio-clock time and not early; the promise-returning path resolves with the event id; repeating events self-chain at `time + count * frequency` (absolute, so drift can't accumulate) with a single queue entry; `updateCallback` swaps mid-stream; `cancel` between schedule and fire silences and stops the source; `clear`/`getEvent` semantics. Tested against a small fake AudioContext/BufferSource harness where advancing the clock fires `onended`.
- **`src/classes/TempoClock.ts`** — beats↔time round-trips at rates 1.0/0.7/0.5; beat continuity across single and stacked rate changes; `nextBoundary(Beat)` lands on exact grid multiples, strictly after `fromTime`; a boundary's beat identity stays fixed across a rate change while its wall-clock time moves (the re-resolve fix); `currentRate` reports the last commanded rate (what `AudioPlayerWrapper.start` inherits at commit time).
- **`src/stores/musicPlayerStore.ts`** — voice lifecycle transitions; order-preserving updates (updating a voice must NOT move it to the array end); poly=1 and poly=N oldest-voice eviction and override replacement; `clearVoiceOverride`; single-solo semantics; mute; reset/randomize callback upsert-by-name registries; timeWarp/energy defaults and setters; full `reset()`.
- **`src/utils/audioUtils.ts`** — `nextSubdivision` boundary math across bpm/beat combos, exact-multiple landing, strictly-after semantics; `loadArrayBuffer` resolves on 200, rejects on non-200 `load` (the hang fix) and on network error, via a minimal fake XHR; `averageVolume`.
- **`src/utils/mathUtils.ts`** — `clamp`, `normalize` (including the doClamp behavior that deliberately differs from the old crco-utils bug: the clamp applies to the 0..1 output), `lerp`, `solveExpEquation`, `linToLog`, `boundedSin`, `gaussianRand`, `rotatePoint`.
- **`src/viz/frameGate.ts`** (extracted from `SceneManager.animate`, behavior-identical, so it's testable without importing three r108) — 60Hz renders every tick; 120Hz exactly every other; simulated 60/90/120/144/165Hz tick trains all average ~60fps; jitter-margin edge; drift clamp resyncs after a long stall.
- **`src/components/effectWalk.ts`** (`chooseNewValue`, moved out of `EffectsPanel.tsx` — unchanged math; a separate module because importing the component drags vanilla-extract styles into the node test run) — full-range behavior matches the documented original constants (bounds 35 / step 40, branch switches at 36/65); margins scale as fractions of the range; the narrowed hp (1-72) and lp (55-100) safe-zone walks stay interior and wander in both directions instead of ratcheting to a bound; deterministic via a seeded `Math.random` spy.

## Pinned-but-flagged oddity

`Scheduler.scheduleOnce` without a callback (the promise path) never removes its event from the queue after firing — only the callback path self-cleans via `cancel`. The test pins the current lingering-entry behavior and marks it as a likely leak; no fix in this PR.

## Gates (all run in the worktree)

- `pnpm test:unit` — 95 passed
- `pnpm typecheck`, `pnpm build` — clean
- `pnpm exec eslint src/` — 0 errors, same 10 pre-existing warnings as dev
- `pnpm test:e2e` — 40 passed (covers the frameGate extraction in the live render loop)