### PR TITLE
ci: run CI on pushes to next branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master, dev]
+    branches: [master, dev, next]
   pull_request:
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Adds `next` (staging) to the push trigger's branch list in `.github/workflows/ci.yml`, alongside `master` and `dev`

## Test plan
- [ ] Push to `next` and confirm the CI workflow (including e2e) fires